### PR TITLE
Picsure 206 connections

### DIFF
--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/data/entity/Connection.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/data/entity/Connection.java
@@ -1,0 +1,57 @@
+package edu.harvard.hms.dbmi.avillach.auth.data.entity;
+
+import edu.harvard.dbmi.avillach.data.entity.BaseEntity;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import java.io.Serializable;
+
+@Entity(name = "connection")
+public class Connection extends BaseEntity implements Serializable {
+
+    private String label;
+
+    @Column(unique = true)
+    private String id;
+    private String subPrefix;
+
+    private String requiredFields;
+
+    public String getLabel() {
+        return label;
+    }
+
+    public Connection setLabel(String label) {
+        this.label = label;
+        return this;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public Connection setId(String id) {
+        this.id = id;
+        return this;
+    }
+
+    public String getSubPrefix() {
+        return subPrefix;
+    }
+
+    public Connection setSubPrefix(String subPrefix) {
+        this.subPrefix = subPrefix;
+        return this;
+    }
+
+    public String getRequiredFields() {
+        return requiredFields;
+    }
+
+    public Connection setRequiredFields(String requiredFields) {
+        this.requiredFields = requiredFields;
+        return this;
+    }
+}
+
+

--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/data/entity/UserMetadataMapping.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/data/entity/UserMetadataMapping.java
@@ -2,25 +2,21 @@ package edu.harvard.hms.dbmi.avillach.auth.data.entity;
 
 import edu.harvard.dbmi.avillach.data.entity.BaseEntity;
 
-import javax.persistence.Entity;
+import javax.persistence.*;
 
 @Entity(name="userMetadataMapping")
 public class UserMetadataMapping extends BaseEntity {
-	
-	private String connectionId;
-	
+
+	@ManyToOne(fetch = FetchType.EAGER)
+	@JoinColumn(
+			name = "connectionId",
+			referencedColumnName = "id"
+	)
+	private Connection connection;
+
 	private String generalMetadataJsonPath;
 	
 	private String auth0MetadataJsonPath;
-
-	public String getConnectionId() {
-		return connectionId;
-	}
-
-	public UserMetadataMapping setConnectionId(String connectionId) {
-		this.connectionId = connectionId;
-		return this;
-	}
 
 	public String getGeneralMetadataJsonPath() {
 		return generalMetadataJsonPath;
@@ -39,5 +35,13 @@ public class UserMetadataMapping extends BaseEntity {
 		this.auth0MetadataJsonPath = auth0MetadataJsonPath;
 		return this;
 	}
-	
+
+	public Connection getConnection() {
+		return connection;
+	}
+
+	public UserMetadataMapping setConnection(Connection connection) {
+		this.connection = connection;
+		return this;
+	}
 }

--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/data/repository/ConnectionRepository.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/data/repository/ConnectionRepository.java
@@ -1,0 +1,40 @@
+package edu.harvard.hms.dbmi.avillach.auth.data.repository;
+
+import edu.harvard.dbmi.avillach.data.repository.BaseRepository;
+import edu.harvard.hms.dbmi.avillach.auth.data.entity.Connection;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.persistence.NoResultException;
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.Root;
+import javax.transaction.Transactional;
+import java.util.UUID;
+
+@Transactional
+@ApplicationScoped
+public class ConnectionRepository extends BaseRepository<Connection, UUID> {
+
+    private Logger logger = LoggerFactory.getLogger(ConnectionRepository.class);
+
+    protected ConnectionRepository() {
+        super(Connection.class);
+    }
+
+    public Connection findConnectionById(String connectionId) {
+        CriteriaQuery<Connection> query = em.getCriteriaBuilder().createQuery(Connection.class);
+        Root<Connection> queryRoot = query.from(Connection.class);
+        query.select(queryRoot);
+        CriteriaBuilder cb = cb();
+        try {
+            return em.createQuery(query
+                    .where(
+                            eq(cb, queryRoot, "id", connectionId)))
+                    .getSingleResult();
+        } catch (NoResultException e){
+            return null;
+        }
+    }
+}

--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/data/repository/UserMetadataMappingRepository.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/data/repository/UserMetadataMappingRepository.java
@@ -1,19 +1,16 @@
 package edu.harvard.hms.dbmi.avillach.auth.data.repository;
 
-import edu.harvard.hms.dbmi.avillach.auth.data.entity.UserMetadataMapping;
 import edu.harvard.dbmi.avillach.data.repository.BaseRepository;
-
+import edu.harvard.hms.dbmi.avillach.auth.data.entity.UserMetadataMapping;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.enterprise.context.ApplicationScoped;
-import javax.persistence.NoResultException;
-import javax.persistence.NonUniqueResultException;
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.Join;
 import javax.persistence.criteria.Root;
 import javax.transaction.Transactional;
-
 import java.util.List;
 import java.util.UUID;
 
@@ -27,14 +24,15 @@ public class UserMetadataMappingRepository extends BaseRepository<UserMetadataMa
 		super(UserMetadataMapping.class);
 	}
 
-	public List<UserMetadataMapping> findByConnection(String subject) {
-		CriteriaQuery<UserMetadataMapping> query = em.getCriteriaBuilder().createQuery(UserMetadataMapping.class);
+	public List<UserMetadataMapping> findByConnection(String connectionId) {
+		CriteriaBuilder cb = cb();
+		CriteriaQuery<UserMetadataMapping> query = cb.createQuery(UserMetadataMapping.class);
 		Root<UserMetadataMapping> queryRoot = query.from(UserMetadataMapping.class);
 		query.select(queryRoot);
-		CriteriaBuilder cb = cb();
+		Join connectionJoin = queryRoot.join("connection");
 		return em.createQuery(query
 				.where(
-						eq(cb, queryRoot, "connectionId", subject)))
+						cb.equal(connectionJoin.get("id"), connectionId)))
 				.getResultList();
 	}
 	

--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/rest/ConnectionWebService.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/rest/ConnectionWebService.java
@@ -1,0 +1,51 @@
+package edu.harvard.hms.dbmi.avillach.auth.rest;
+
+import edu.harvard.hms.dbmi.avillach.auth.data.entity.Connection;
+import edu.harvard.hms.dbmi.avillach.auth.data.repository.ConnectionRepository;
+import edu.harvard.hms.dbmi.avillach.auth.service.BaseEntityService;
+
+import javax.inject.Inject;
+import javax.transaction.Transactional;
+import javax.ws.rs.*;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import java.util.List;
+
+@Path("connection")
+public class ConnectionWebService extends BaseEntityService<Connection> {
+
+    public ConnectionWebService() {
+        super(Connection.class);
+    }
+
+    @Inject
+    ConnectionRepository connectionRepo;
+
+    @Path("{connectionId}")
+    @GET
+    @Produces("application/json")
+    public Response getConnectionById(@PathParam("connectionId") String connection) {
+        return Response.ok(connectionRepo.findConnectionById(connection)).build();
+    }
+
+    @GET
+    @Produces("application/json")
+    public Response getAllConnections() {
+        return getEntityAll(connectionRepo);
+    }
+
+    @Transactional
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Path("/")
+    public Response addConnection(List<Connection> connections){
+        return addEntity(connections, connectionRepo);
+    }
+
+    @Transactional
+    @DELETE
+    @Path("/{connectionId}")
+    public Response removeById(@PathParam("connectionId") final String connectionId) {
+        return removeEntityById(connectionId, connectionRepo);
+    }
+}

--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/rest/ConnectionWebService.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/rest/ConnectionWebService.java
@@ -42,6 +42,13 @@ public class ConnectionWebService extends BaseEntityService<Connection> {
         return addEntity(connections, connectionRepo);
     }
 
+    @PUT
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Path("/")
+    public Response updateConnection(List<Connection> connections){
+        return updateEntity(connections, connectionRepo);
+    }
+
     @Transactional
     @DELETE
     @Path("/{connectionId}")

--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/rest/ConnectionWebService.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/rest/ConnectionWebService.java
@@ -1,5 +1,6 @@
 package edu.harvard.hms.dbmi.avillach.auth.rest;
 
+import edu.harvard.dbmi.avillach.util.response.PICSUREResponse;
 import edu.harvard.hms.dbmi.avillach.auth.data.entity.Connection;
 import edu.harvard.hms.dbmi.avillach.auth.data.repository.ConnectionRepository;
 import edu.harvard.hms.dbmi.avillach.auth.service.BaseEntityService;
@@ -39,7 +40,7 @@ public class ConnectionWebService extends BaseEntityService<Connection> {
     @Consumes(MediaType.APPLICATION_JSON)
     @Path("/")
     public Response addConnection(List<Connection> connections){
-        return addEntity(connections, connectionRepo);
+        return addEntity(connections);
     }
 
     @PUT
@@ -54,5 +55,18 @@ public class ConnectionWebService extends BaseEntityService<Connection> {
     @Path("/{connectionId}")
     public Response removeById(@PathParam("connectionId") final String connectionId) {
         return removeEntityById(connectionId, connectionRepo);
+    }
+
+    private Response addEntity(List<Connection> connections){
+        for (Connection c : connections){
+            if (c.getSubPrefix() == null || c.getRequiredFields() == null || c.getLabel() == null || c.getId() == null){
+                return PICSUREResponse.protocolError("Id, Label, Subprefix, and RequiredFields cannot be null");
+            }
+            Connection conn = connectionRepo.findConnectionById(c.getId());
+            if (conn != null){
+                return PICSUREResponse.protocolError("Id must be unique, a connection with id " + c.getId() + " already exists in the database");
+            }
+        }
+        return addEntity(connections, connectionRepo);
     }
 }

--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/rest/ConnectionWebService.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/rest/ConnectionWebService.java
@@ -24,8 +24,8 @@ public class ConnectionWebService extends BaseEntityService<Connection> {
     @Path("{connectionId}")
     @GET
     @Produces("application/json")
-    public Response getConnectionById(@PathParam("connectionId") String connection) {
-        return Response.ok(connectionRepo.findConnectionById(connection)).build();
+    public Response getConnectionById(@PathParam("connectionId") String connectionId) {
+        return getEntityById(connectionId,connectionRepo);
     }
 
     @GET

--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/rest/UserMetadataMappingWebService.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/rest/UserMetadataMappingWebService.java
@@ -47,6 +47,13 @@ public class UserMetadataMappingWebService  extends BaseEntityService<UserMetada
 		return mappingService.addMappings(mappings);
 	}
 
+	@PUT
+	@Consumes(MediaType.APPLICATION_JSON)
+	@Path("/")
+	public Response updateMapping(List<UserMetadataMapping> mappings) {
+		return updateEntity(mappings, mappingRepo);
+	}
+
 	@Transactional
 	@DELETE
 	@Path("/{mappingId}")

--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/rest/UserMetadataMappingWebService.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/rest/UserMetadataMappingWebService.java
@@ -1,15 +1,16 @@
 package edu.harvard.hms.dbmi.avillach.auth.rest;
 
-import javax.inject.Inject;
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.Response;
-
 import edu.harvard.hms.dbmi.avillach.auth.data.entity.UserMetadataMapping;
+import edu.harvard.hms.dbmi.avillach.auth.data.repository.UserMetadataMappingRepository;
 import edu.harvard.hms.dbmi.avillach.auth.service.BaseEntityService;
 import edu.harvard.hms.dbmi.avillach.auth.service.UserMetadataMappingService;
+
+import javax.inject.Inject;
+import javax.transaction.Transactional;
+import javax.ws.rs.*;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import java.util.List;
 
 @Path("mapping")
 public class UserMetadataMappingWebService  extends BaseEntityService<UserMetadataMapping>{
@@ -20,6 +21,10 @@ public class UserMetadataMappingWebService  extends BaseEntityService<UserMetada
 
 	@Inject
 	UserMetadataMappingService mappingService;
+
+	@Inject
+	UserMetadataMappingRepository mappingRepo;
+
 	
 	@Path("{connectionId}")
 	@GET
@@ -33,6 +38,19 @@ public class UserMetadataMappingWebService  extends BaseEntityService<UserMetada
 	public Response getAllMappings() {
 		return Response.ok(mappingService.getAllMappings()).build();
 	}
-	
-	
+
+	@Transactional
+	@POST
+	@Consumes(MediaType.APPLICATION_JSON)
+	@Path("/")
+	public Response addMapping(List<UserMetadataMapping> mappings) {
+		return mappingService.addMappings(mappings);
+	}
+
+	@Transactional
+	@DELETE
+	@Path("/{mappingId}")
+	public Response removeById(@PathParam("mappingId") final String mappingId) {
+		return removeEntityById(mappingId, mappingRepo);
+	}
 }

--- a/pic-sure-auth-services/src/main/resources/db/picsure2-dump-initial.sql
+++ b/pic-sure-auth-services/src/main/resources/db/picsure2-dump-initial.sql
@@ -76,7 +76,7 @@ CREATE TABLE `user` (
   `uuid` binary(16) NOT NULL,
   `auth0_metadata` varchar(8000) COLLATE utf8_bin DEFAULT NULL,
   `general_metadata` varchar(9000) COLLATE utf8_bin DEFAULT NULL,
-  `acceptedTOS` timestamp COLLATE utf8_bin DEFAULT NULL,
+  `acceptedTOS` datetime COLLATE utf8_bin DEFAULT NULL,
   `connectionId` varchar(255) COLLATE utf8_bin DEFAULT NULL,
   `email` varchar(255) COLLATE utf8_bin DEFAULT NULL,
   `matched` bit(1) NOT NULL DEFAULT FALSE,

--- a/pic-sure-auth-services/src/main/resources/db/picsure2-dump-initial.sql
+++ b/pic-sure-auth-services/src/main/resources/db/picsure2-dump-initial.sql
@@ -127,6 +127,16 @@ CREATE TABLE `termsOfService` (
   PRIMARY KEY (`uuid`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
 
+CREATE TABLE `connection` (
+  `uuid` binary(16) NOT NULL,
+  `label` varchar(255) COLLATE utf8_bin DEFAULT NULL,
+  `id` varchar(255) COLLATE utf8_bin DEFAULT NULL,
+  `subPrefix` varchar(255) COLLATE utf8_bin DEFAULT NULL,
+  `requiredFields` varchar(9000) COLLATE utf8_bin DEFAULT NULL,
+  PRIMARY KEY (`uuid`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
+
+
 /*!40101 SET SQL_MODE=@OLD_SQL_MODE */;
 /*!40014 SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS */;
 /*!40014 SET UNIQUE_CHECKS=@OLD_UNIQUE_CHECKS */;

--- a/pic-sure-auth-services/src/main/resources/db/picsure2-dump-initial.sql
+++ b/pic-sure-auth-services/src/main/resources/db/picsure2-dump-initial.sql
@@ -127,14 +127,19 @@ CREATE TABLE `termsOfService` (
   PRIMARY KEY (`uuid`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
 
+DROP TABLE IF EXISTS `connection`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `connection` (
   `uuid` binary(16) NOT NULL,
-  `label` varchar(255) COLLATE utf8_bin DEFAULT NULL,
-  `id` varchar(255) COLLATE utf8_bin DEFAULT NULL,
-  `subPrefix` varchar(255) COLLATE utf8_bin DEFAULT NULL,
-  `requiredFields` varchar(9000) COLLATE utf8_bin DEFAULT NULL,
-  PRIMARY KEY (`uuid`)
+  `label` varchar(255) COLLATE utf8_bin NOT NULL,
+  `id` varchar(255) COLLATE utf8_bin NOT NULL,
+  `subprefix` varchar(255) COLLATE utf8_bin NOT NULL,
+  `requiredFields` varchar(9000) COLLATE utf8_bin NOT NULL,
+  PRIMARY KEY (`uuid`),
+  UNIQUE KEY `id` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
 
 
 /*!40101 SET SQL_MODE=@OLD_SQL_MODE */;

--- a/pic-sure-auth-services/src/test/java/edu/harvard/hms/dbmi/avillach/Auth0MatchingServiceTest.java
+++ b/pic-sure-auth-services/src/test/java/edu/harvard/hms/dbmi/avillach/Auth0MatchingServiceTest.java
@@ -4,6 +4,7 @@ import com.auth0.exception.Auth0Exception;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import edu.harvard.hms.dbmi.avillach.auth.data.entity.Connection;
 import edu.harvard.hms.dbmi.avillach.auth.data.entity.User;
 import edu.harvard.hms.dbmi.avillach.auth.data.entity.UserMetadataMapping;
 import edu.harvard.hms.dbmi.avillach.auth.data.repository.UserRepository;
@@ -25,7 +26,8 @@ import java.util.stream.Collectors;
 
 import static junit.framework.TestCase.assertNotNull;
 import static junit.framework.TestCase.assertTrue;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
@@ -161,15 +163,16 @@ public class Auth0MatchingServiceTest {
 
     private List<UserMetadataMapping> getAllMappingsForConnectionMock(String connectionId) {
         List<UserMetadataMapping> allMappings = List.of(
-                new UserMetadataMapping().setConnectionId("ldap-connector").setGeneralMetadataJsonPath("$.email").setAuth0MetadataJsonPath("$.email"),
-                new UserMetadataMapping().setConnectionId("nih-gov-prod").setGeneralMetadataJsonPath("$.nih-userid").setAuth0MetadataJsonPath("$.identities[0].user_id"),
-                new UserMetadataMapping().setConnectionId("github").setGeneralMetadataJsonPath("$.full_name").setAuth0MetadataJsonPath("$.name"),
-                new UserMetadataMapping().setConnectionId("github").setGeneralMetadataJsonPath("$.email").setAuth0MetadataJsonPath("$.emails[?(@.primary == true)].email"),
-                new UserMetadataMapping().setConnectionId("no-user-connection").setGeneralMetadataJsonPath("$.email").setAuth0MetadataJsonPath("$.email"),
-                new UserMetadataMapping().setConnectionId("invalid-path").setGeneralMetadataJsonPath("$.email").setAuth0MetadataJsonPath("$.noPath")
+                new UserMetadataMapping().setConnection(new Connection().setId("ldap-connector")).setGeneralMetadataJsonPath("$.email").setAuth0MetadataJsonPath("$.email"),
+                new UserMetadataMapping().setConnection(new Connection().setId("nih-gov-prod")).setGeneralMetadataJsonPath("$.nih-userid").setAuth0MetadataJsonPath("$.identities[0].user_id"),
+                new UserMetadataMapping().setConnection(new Connection().setId("github")).setGeneralMetadataJsonPath("$.full_name").setAuth0MetadataJsonPath("$.name"),
+                new UserMetadataMapping().setConnection(new Connection().setId("github")).setGeneralMetadataJsonPath("$.email").setAuth0MetadataJsonPath("$.emails[?(@.primary == true)].email"),
+                new UserMetadataMapping().setConnection(new Connection().setId("no-user-connection")).setGeneralMetadataJsonPath("$.email").setAuth0MetadataJsonPath("$.email"),
+                new UserMetadataMapping().setConnection(new Connection().setId("invalid-path")).setGeneralMetadataJsonPath("$.email").setAuth0MetadataJsonPath("$.noPath")
+
                 );
         return allMappings.stream().filter((UserMetadataMapping mapping) -> {
-            return mapping.getConnectionId().equalsIgnoreCase(connectionId);
+            return mapping.getConnection().getId().equalsIgnoreCase(connectionId);
         }).collect(Collectors.toList());
     }
 


### PR DESCRIPTION
Endpoints are not role-restricted yet, but they're there.
For the UserMetadataMappingService, I currently simply return a message about which connectionIds don't exist if any don't.  Is there a better way to do this?  Additionally, in this case, should the mappings with valid connectionIds be created, or should they all fail?