### PR TITLE
picsure 276 fix bug of missing email field

### DIFF
--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/auth/AuthenticationService.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/auth/AuthenticationService.java
@@ -73,9 +73,12 @@ public class AuthenticationService {
             }
         }
 
+        Map<String, Object> claims = generateClaims(userInfo, new String[]{"user_id","name" });
+        claims.put("email",user.getEmail());
+
         String token = JWTUtil.createJwtToken(
                 JAXRSConfiguration.clientSecret, null, null,
-                generateClaims(userInfo, new String[]{"user_id", "email","name" }),
+                claims,
                 userId, 1000 * 60 * 60 * 24);
 
         boolean acceptedTOS = JAXRSConfiguration.tosEnabled.startsWith("true") ? 
@@ -85,7 +88,7 @@ public class AuthenticationService {
         
         responseMap.put("token", token);
         responseMap.put("name", (userInfo.has("name")?userInfo.get("name").asText():null));
-        responseMap.put("email", userInfo.has("email")?userInfo.get("email").asText():null);
+        responseMap.put("email", user.getEmail());
         responseMap.put("userId", user.getUuid().toString());
         responseMap.put("acceptedTOS", ""+acceptedTOS);
         


### PR DESCRIPTION
I checked the entire adding user logic and debugged by adding an actual user. I believe with this fixation, in any cases, there will be an email field returns now, since our current work flow will always have a field email