### PR TITLE
standalone.xml attributes added, compatible to any existing environments

### DIFF
--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/JAXRSConfiguration.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/JAXRSConfiguration.java
@@ -121,8 +121,8 @@ public class JAXRSConfiguration extends Application {
     private void initializeTokenExpirationTime(){
         try {
             Context ctx = new InitialContext();
-            tokenExpirationTime = (long)ctx.lookup("java:global/tokenExpirationTime");
-        } catch (NamingException | ClassCastException ex){
+            tokenExpirationTime = Long.parseLong((String)ctx.lookup("java:global/tokenExpirationTime"));
+        } catch (NamingException | ClassCastException | NumberFormatException ex){
             tokenExpirationTime = defaultTokenExpirationTime;
         }
 
@@ -133,8 +133,8 @@ public class JAXRSConfiguration extends Application {
     private void initializeLongTermTokenExpirationTime(){
         try {
             Context ctx = new InitialContext();
-            longTermTokenExpirationTime = (long)ctx.lookup("java:global/longTermTokenExpirationTime");
-        } catch (NamingException | ClassCastException ex){
+            longTermTokenExpirationTime = Long.parseLong((String)ctx.lookup("java:global/longTermTokenExpirationTime"));
+        } catch (NamingException | ClassCastException | NumberFormatException ex){
             longTermTokenExpirationTime = defaultLongTermTokenExpirationTime;
         }
 

--- a/pic-sure-auth-services/src/main/resources/wildfly-configuration/standalone.xml
+++ b/pic-sure-auth-services/src/main/resources/wildfly-configuration/standalone.xml
@@ -447,6 +447,7 @@
                 <simple name="java:global/deniedEmailEnabled" value="${env.DENIED_EMAIL_ENABLED:true}"/>
                 <simple name="java:global/adminUsers" value="${env.COMMA_SEPARATED_EMAILS:none}"/>
                 <simple name="java:global/accessGrantEmailSubject" value="${env.accessGrantEmailSubject:none}"/>
+                <simple name="java:global/tokenExpirationTime" value="${env.tokenExpriationTime:900000}" />
             </bindings>
             <remote-naming/>
         </subsystem>


### PR DESCRIPTION
added one more attribute into standalone.xml. Including this attribute or not will not affect any existing environments.

And fixed the bug when converting the configuration expiration time

see test results:
<img width="1346" alt="image" src="https://user-images.githubusercontent.com/33844814/63135102-74629f80-bf9a-11e9-94d4-b092282b8267.png">
the default is 900,000 and now it is 1,800,000, meaning the code works