### PR TITLE
only path ends with swagger.json or swagger.yaml can pass the filter

### DIFF
--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/security/JWTFilter.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/security/JWTFilter.java
@@ -57,7 +57,9 @@ public class JWTFilter implements ContainerRequestFilter {
 		/**
 		 * skip the filter in certain cases
 		 */
-		if (uriInfo.getPath().endsWith("authentication")) {
+		if (uriInfo.getPath().endsWith("authentication")
+				|| uriInfo.getPath().endsWith("/swagger.yaml")
+				|| uriInfo.getPath().endsWith("/swagger.json")) {
 			return;
 		}
 


### PR DESCRIPTION
Test results: trying to break into the system:
<img width="515" alt="image" src="https://user-images.githubusercontent.com/33844814/65529466-2a87a600-dec4-11e9-980f-30ec30e0140b.png">

