### PR TITLE
revert back to pass only request block in inputMap

### DIFF
--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/rest/TokenService.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/rest/TokenService.java
@@ -249,6 +249,9 @@ public class TokenService {
         } else if (user != null
                 && !isLongTermTokenCompromised
                 && user.getRoles() != null
+                // The protocol between applications and PSAMA is application will
+                // attach everything that needs to be verified in request field of inputMap
+                // besides token. So here we should attach everything in request.
 				&& authorizationService.isAuthorized(application, inputMap.get("request"), user)) {
 			isAuthorizationPassed = true;
 		} else {

--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/rest/TokenService.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/rest/TokenService.java
@@ -249,7 +249,7 @@ public class TokenService {
         } else if (user != null
                 && !isLongTermTokenCompromised
                 && user.getRoles() != null
-				&& authorizationService.isAuthorized(application, inputMap, user)) {
+				&& authorizationService.isAuthorized(application, inputMap.get("request"), user)) {
 			isAuthorizationPassed = true;
 		} else {
             // if isLongTermTokenCompromised flag is true,


### PR DESCRIPTION
The protocol between applications and PSAMA is that everything needs to be verified except token should be in request field. Need to comment it in the code and record this protocol in documentation.