### PR TITLE
[ALS-4793] Modify PSAMA to bypass fence

### DIFF
--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/auth/FENCEAuthenticationService.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/auth/FENCEAuthenticationService.java
@@ -157,12 +157,6 @@ public class FENCEAuthenticationService {
         logger.debug("getFENCEProfile() starting...");
         String fence_code  = authRequest.get("code");
 
-        // Validate that the fence code is alphanumeric
-        if (!fence_code.matches("[a-zA-Z0-9]+")) {
-            logger.error("getFENCEProfile() fence code is not alphanumeric");
-            throw new NotAuthorizedException("The fence code is not alphanumeric");
-        }
-
         JsonNode fence_user_profile = null;
         // Get the Gen3/FENCE user profile. It is a JsonNode object
         try {

--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/auth/FENCEAuthenticationService.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/auth/FENCEAuthenticationService.java
@@ -157,6 +157,12 @@ public class FENCEAuthenticationService {
         logger.debug("getFENCEProfile() starting...");
         String fence_code  = authRequest.get("code");
 
+        // Validate that the fence code is alphanumeric
+        if (!fence_code.matches("[a-zA-Z0-9]+")) {
+            logger.error("getFENCEProfile() fence code is not alphanumeric");
+            throw new NotAuthorizedException("The fence code is not alphanumeric");
+        }
+
         JsonNode fence_user_profile = null;
         // Get the Gen3/FENCE user profile. It is a JsonNode object
         try {

--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/auth/OpenAuthenticationService.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/auth/OpenAuthenticationService.java
@@ -36,8 +36,12 @@ public class OpenAuthenticationService {
 
         // Try to get the user by UUID
         if (StringUtils.isNotBlank(userUUID)) {
-            UUID uuid = UUID.fromString(userUUID);
-            current_user = userRepository.findByUUID(uuid);
+            try {
+                UUID uuid = UUID.fromString(userUUID);
+                current_user = userRepository.findByUUID(uuid);
+            } catch (IllegalArgumentException e) {
+                logger.error("Invalid UUID: " + userUUID);
+            }
         }
 
         // If we can't find the user by UUID, create a new one


### PR DESCRIPTION
Update PSAMA to by pass the use of Fence for Open Access. The new endpoint, `/open/authenticate`, accepts either a UUID or an empty value. When no UUID is provided, a new user is created. If a valid UUID is given, the system tries to retrieve an existing user. If the user isn't found, a new one is returned.