### PR TITLE
[ALS-5858] AIM-AHEAD PIC-SURE: Landing page shows 0 studies

### DIFF
--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/JAXRSConfiguration.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/JAXRSConfiguration.java
@@ -102,7 +102,7 @@ public class JAXRSConfiguration extends Application {
     public static String fence_allowed_query_types;
     public static String defaultAdminRoleName = "PIC-SURE Top Admin";
     public static String spClientSecret;
-    
+
     public static String connectionId;
     public static String clientId;
     public static long tokenExpirationTime;
@@ -193,42 +193,13 @@ public class JAXRSConfiguration extends Application {
                 fence_client_secret = (String) ctx.lookup("java:global/fence_client_secret");
                 fence_redirect_url = (String) ctx.lookup("java:global/fence_redirect_url");
 
-                fence_parent_consent_group_concept_path = (String) ctx.lookup("java:global/fence_parent_consent_group_concept_path");
-                if (fence_parent_consent_group_concept_path == null) {
-                    logger.error("checkIDPProvider() Empty parent consent group concept path from standalone.xml. Using default!");
-                    fence_parent_consent_group_concept_path = "\\\\_Consents\\\\Short Study Accession with Consent code\\\\";
-                }
+                getFenceParentConsentGroupConceptPath(ctx);
+                getFenceHarmonizaedGroupConsentPath(ctx);
+                getFenceTopmedConsentGroupPath(ctx);
+                getFenceStandardAccessRules(ctx);
+                getFenceAllowedQueryTypes(ctx);
+                getFenceHarmonizedConceptPath(ctx);
 
-                fence_harmonized_consent_group_concept_path = (String) ctx.lookup("java:global/fence_harmonized_consent_group_concept_path");
-                if (fence_harmonized_consent_group_concept_path == null) {
-                    logger.error("checkIDPProvider() Empty harmonized consent group concept path from standalone.xml. Using default!");
-                    fence_harmonized_consent_group_concept_path = "\\\\_Consents\\\\Short Study Accession with Consent code\\\\";
-                }
-
-                fence_topmed_consent_group_concept_path = (String) ctx.lookup("java:global/fence_topmed_consent_group_concept_path");
-                if (fence_topmed_consent_group_concept_path == null) {
-                    logger.error("checkIDPProvider() Empty topmed consent group concept path from standalone.xml. Using default!");
-                    fence_topmed_consent_group_concept_path = "\\\\_Consents\\\\Short Study Accession with Consent code\\\\";
-                }
-
-                fence_standard_access_rules = (String) ctx.lookup("java:global/fence_standard_access_rules");
-                if (fence_standard_access_rules.isEmpty()) {
-                    logger.error("checkIDPProvider() Missing Standard Access Rules in standalone.xml. Using defaults.");
-                    fence_standard_access_rules = "GATE_ONLY_INFO,GATE_ONLY_QUERY,GATE_ONLY_SEARCH,GATE_FENCE_CONSENT_REQUIRED";
-                }
-
-                fence_allowed_query_types = (String) ctx.lookup("java:global/fence_allowed_query_types");
-                if (fence_allowed_query_types.isEmpty()) {
-                    logger.error("checkIDPProvider() Missing Allowed query types from standalone.xml. Using defaults.");
-                    fence_allowed_query_types = "COUNT,CROSS_COUNT";
-                }
-
-
-                fence_harmonized_concept_path = (String) ctx.lookup("java:global/fence_harmonized_concept_path");
-                if (fence_harmonized_concept_path.isEmpty()) {
-                    logger.error("checkIDPProvider() Empty harmonized concept path. Not in use.");
-                    fence_harmonized_concept_path = "";
-                }
                 logger.debug("checkIDPProvider() idp provider FENCE is configured");
 
                 // Upsert FENCE connection
@@ -263,6 +234,13 @@ public class JAXRSConfiguration extends Application {
                 connectionId = (String) ctx.lookup("java:global/connection_id");
                 clientId = (String) ctx.lookup("java:global/client_id");
 
+                getFenceParentConsentGroupConceptPath(ctx);
+                getFenceHarmonizaedGroupConsentPath(ctx);
+                getFenceTopmedConsentGroupPath(ctx);
+                getFenceStandardAccessRules(ctx);
+                getFenceAllowedQueryTypes(ctx);
+                getFenceHarmonizedConceptPath(ctx);
+
                 logger.debug("checkIDPProvider() idp provider OKTA is configured");
             } catch (Exception ex) {
                 logger.error("checkIDPProvider() " + ex.getMessage());
@@ -274,6 +252,54 @@ public class JAXRSConfiguration extends Application {
                     "Check configuration in standalone.xml");
         }
         logger.debug("checkIDPProvider() finished");
+    }
+
+    private void getFenceTopmedConsentGroupPath(Context ctx) throws NamingException {
+        fence_topmed_consent_group_concept_path = (String) ctx.lookup("java:global/fence_topmed_consent_group_concept_path");
+        if (fence_topmed_consent_group_concept_path == null) {
+            logger.error("checkIDPProvider() Empty topmed consent group concept path from standalone.xml. Using default!");
+            fence_topmed_consent_group_concept_path = "\\\\_Consents\\\\Short Study Accession with Consent code\\\\";
+        }
+    }
+
+    private void getFenceHarmonizaedGroupConsentPath(Context ctx) throws NamingException {
+        fence_harmonized_consent_group_concept_path = (String) ctx.lookup("java:global/fence_harmonized_consent_group_concept_path");
+        if (fence_harmonized_consent_group_concept_path == null) {
+            logger.error("checkIDPProvider() Empty harmonized consent group concept path from standalone.xml. Using default!");
+            fence_harmonized_consent_group_concept_path = "\\\\_Consents\\\\Short Study Accession with Consent code\\\\";
+        }
+    }
+
+    private void getFenceStandardAccessRules(Context ctx) throws NamingException {
+        fence_standard_access_rules = (String) ctx.lookup("java:global/fence_standard_access_rules");
+        if (fence_standard_access_rules.isEmpty()) {
+            logger.error("checkIDPProvider() Missing Standard Access Rules in standalone.xml. Using defaults.");
+            fence_standard_access_rules = "GATE_ONLY_INFO,GATE_ONLY_QUERY,GATE_ONLY_SEARCH,GATE_FENCE_CONSENT_REQUIRED";
+        }
+    }
+
+    private void getFenceHarmonizedConceptPath(Context ctx) throws NamingException {
+        fence_harmonized_concept_path = (String) ctx.lookup("java:global/fence_harmonized_concept_path");
+        if (fence_harmonized_concept_path.isEmpty()) {
+            logger.error("checkIDPProvider() Empty harmonized concept path. Not in use.");
+            fence_harmonized_concept_path = "";
+        }
+    }
+
+    private void getFenceParentConsentGroupConceptPath(Context ctx) throws NamingException {
+        fence_parent_consent_group_concept_path = (String) ctx.lookup("java:global/fence_parent_consent_group_concept_path");
+        if (fence_parent_consent_group_concept_path == null) {
+            logger.error("checkIDPProvider() Empty parent consent group concept path from standalone.xml. Using default!");
+            fence_parent_consent_group_concept_path = "\\\\_Consents\\\\Short Study Accession with Consent code\\\\";
+        }
+    }
+
+    private void getFenceAllowedQueryTypes(Context ctx) throws NamingException {
+        fence_allowed_query_types = (String) ctx.lookup("java:global/fence_allowed_query_types");
+        if (fence_allowed_query_types.isEmpty()) {
+            logger.error("checkIDPProvider() Missing Allowed query types from standalone.xml. Using defaults.");
+            fence_allowed_query_types = "COUNT,CROSS_COUNT";
+        }
     }
 
     private void initializeTokenExpirationTime(Context ctx) {

--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/JAXRSConfiguration.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/JAXRSConfiguration.java
@@ -10,6 +10,7 @@ import edu.harvard.hms.dbmi.avillach.auth.data.repository.PrivilegeRepository;
 import edu.harvard.hms.dbmi.avillach.auth.data.repository.RoleRepository;
 import edu.harvard.hms.dbmi.avillach.auth.rest.TokenService;
 import io.swagger.jaxrs.config.BeanConfig;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.http.client.HttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.slf4j.Logger;
@@ -256,7 +257,7 @@ public class JAXRSConfiguration extends Application {
 
     private void getFenceTopmedConsentGroupPath(Context ctx) throws NamingException {
         fence_topmed_consent_group_concept_path = (String) ctx.lookup("java:global/fence_topmed_consent_group_concept_path");
-        if (fence_topmed_consent_group_concept_path == null) {
+        if (StringUtils.isBlank(fence_topmed_consent_group_concept_path)) {
             logger.error("checkIDPProvider() Empty topmed consent group concept path from standalone.xml. Using default!");
             fence_topmed_consent_group_concept_path = "\\\\_Consents\\\\Short Study Accession with Consent code\\\\";
         }
@@ -264,7 +265,7 @@ public class JAXRSConfiguration extends Application {
 
     private void getFenceHarmonizaedGroupConsentPath(Context ctx) throws NamingException {
         fence_harmonized_consent_group_concept_path = (String) ctx.lookup("java:global/fence_harmonized_consent_group_concept_path");
-        if (fence_harmonized_consent_group_concept_path == null) {
+        if (StringUtils.isBlank(fence_harmonized_consent_group_concept_path)) {
             logger.error("checkIDPProvider() Empty harmonized consent group concept path from standalone.xml. Using default!");
             fence_harmonized_consent_group_concept_path = "\\\\_Consents\\\\Short Study Accession with Consent code\\\\";
         }
@@ -272,7 +273,7 @@ public class JAXRSConfiguration extends Application {
 
     private void getFenceStandardAccessRules(Context ctx) throws NamingException {
         fence_standard_access_rules = (String) ctx.lookup("java:global/fence_standard_access_rules");
-        if (fence_standard_access_rules.isEmpty()) {
+        if (StringUtils.isBlank(fence_standard_access_rules)) {
             logger.error("checkIDPProvider() Missing Standard Access Rules in standalone.xml. Using defaults.");
             fence_standard_access_rules = "GATE_ONLY_INFO,GATE_ONLY_QUERY,GATE_ONLY_SEARCH,GATE_FENCE_CONSENT_REQUIRED";
         }
@@ -280,7 +281,7 @@ public class JAXRSConfiguration extends Application {
 
     private void getFenceHarmonizedConceptPath(Context ctx) throws NamingException {
         fence_harmonized_concept_path = (String) ctx.lookup("java:global/fence_harmonized_concept_path");
-        if (fence_harmonized_concept_path.isEmpty()) {
+        if (StringUtils.isBlank(fence_harmonized_concept_path)) {
             logger.error("checkIDPProvider() Empty harmonized concept path. Not in use.");
             fence_harmonized_concept_path = "";
         }
@@ -288,7 +289,7 @@ public class JAXRSConfiguration extends Application {
 
     private void getFenceParentConsentGroupConceptPath(Context ctx) throws NamingException {
         fence_parent_consent_group_concept_path = (String) ctx.lookup("java:global/fence_parent_consent_group_concept_path");
-        if (fence_parent_consent_group_concept_path == null) {
+        if (StringUtils.isBlank(fence_parent_consent_group_concept_path)) {
             logger.error("checkIDPProvider() Empty parent consent group concept path from standalone.xml. Using default!");
             fence_parent_consent_group_concept_path = "\\\\_Consents\\\\Short Study Accession with Consent code\\\\";
         }
@@ -296,7 +297,7 @@ public class JAXRSConfiguration extends Application {
 
     private void getFenceAllowedQueryTypes(Context ctx) throws NamingException {
         fence_allowed_query_types = (String) ctx.lookup("java:global/fence_allowed_query_types");
-        if (fence_allowed_query_types.isEmpty()) {
+        if (StringUtils.isBlank(fence_allowed_query_types)) {
             logger.error("checkIDPProvider() Missing Allowed query types from standalone.xml. Using defaults.");
             fence_allowed_query_types = "COUNT,CROSS_COUNT";
         }

--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/auth/OktaOAuthAuthenticationService.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/auth/OktaOAuthAuthenticationService.java
@@ -1,6 +1,5 @@
 package edu.harvard.hms.dbmi.avillach.auth.service.auth;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import edu.harvard.dbmi.avillach.util.HttpClientUtil;


### PR DESCRIPTION
In order to upsert user studies we needed many of the same configuration values depended on by FENCE. I have refactored common JAXRSConfigurations to methods. They are now reused across different idp provider configurations.