### PR TITLE
[ALS-5979] AIM-AHEAD PIC-SURE: Downloaded dataset seems incorrect

### DIFF
--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/auth/FENCEAuthenticationService.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/auth/FENCEAuthenticationService.java
@@ -514,11 +514,18 @@ public class FENCEAuthenticationService {
                     +"\":[\""
                     +studyIdentifierField
                     +"\"]},"
-                    +"\"numericFilters\":{},\"requiredFields\":[],"
-                    +"\"fields\":[\"" + parentAccessionField + "\"],"
-                    +"\"variantInfoFilters\":[{\"categoryVariantInfoFilters\":{},\"numericVariantInfoFilters\":{}}],"
+                    +"\"numericFilters\":{},\"requiredFields\":[],";
+
+                    if(JAXRSConfiguration.idp_provider.equalsIgnoreCase("fence")) {
+                    	queryTemplateText += "\"fields\":[\"" + parentAccessionField + "\"],";
+                    } else {
+                        queryTemplateText += "\"fields\":[\"\"],";
+                    }
+
+                    queryTemplateText+="\"variantInfoFilters\":[{\"categoryVariantInfoFilters\":{},\"numericVariantInfoFilters\":{}}],"
                     +"\"expectedResultType\": \"COUNT\""
                     +"}";
+
             priv.setQueryTemplate(queryTemplateText);
             if(isHarmonized) {
             	priv.setQueryScope("[\"" + conceptPath + "\",\"_\",\"" + fence_harmonized_concept_path + "\"]");

--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/auth/FENCEAuthenticationService.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/auth/FENCEAuthenticationService.java
@@ -516,7 +516,7 @@ public class FENCEAuthenticationService {
                     +"\"]},"
                     +"\"numericFilters\":{},\"requiredFields\":[],";
 
-                    if(JAXRSConfiguration.idp_provider.equalsIgnoreCase("fence")) {
+                    if("fence".equalsIgnoreCase(JAXRSConfiguration.idp_provider)) {
                     	queryTemplateText += "\"fields\":[\"" + parentAccessionField + "\"],";
                     } else {
                         queryTemplateText += "\"fields\":[],";

--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/auth/FENCEAuthenticationService.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/auth/FENCEAuthenticationService.java
@@ -519,7 +519,7 @@ public class FENCEAuthenticationService {
                     if(JAXRSConfiguration.idp_provider.equalsIgnoreCase("fence")) {
                     	queryTemplateText += "\"fields\":[\"" + parentAccessionField + "\"],";
                     } else {
-                        queryTemplateText += "\"fields\":[\"\"],";
+                        queryTemplateText += "\"fields\":[],";
                     }
 
                     queryTemplateText+="\"variantInfoFilters\":[{\"categoryVariantInfoFilters\":{},\"numericVariantInfoFilters\":{}}],"


### PR DESCRIPTION
When a study is added for AIM-AHEAD or any non-fence environment we no longer include the `parentAccessionField`.