### PR TITLE
[ALS-6398] BDC Auth: Cookie Does Not Contain The "HTTPOnly" Attribute

### DIFF
--- a/pic-sure-auth-services/src/main/resources/application.properties
+++ b/pic-sure-auth-services/src/main/resources/application.properties
@@ -77,3 +77,6 @@ application.long.term.token.expiration.time=${LONG_TERM_TOKEN_EXPIRATION_TIME:25
 
 # Logging
 #logging.level.org.springframework.security=TRACE
+
+server.servlet.session.cookie.http-only=true
+server.servlet.session.cookie.secure=true


### PR DESCRIPTION
[ALS-6398] BDC Auth: Cookie Does Not Contain The "HTTPOnly" Attribute