### PR TITLE
[ALS-6103] Study Access

### DIFF
--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/rest/StudyAccessController.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/rest/StudyAccessController.java
@@ -4,6 +4,7 @@ import edu.harvard.hms.dbmi.avillach.auth.model.response.PICSUREResponse;
 import edu.harvard.hms.dbmi.avillach.auth.service.impl.StudyAccessService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import jakarta.annotation.security.RolesAllowed;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.annotation.Secured;
@@ -11,8 +12,10 @@ import org.springframework.stereotype.Controller;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 
 
+import static edu.harvard.hms.dbmi.avillach.auth.utils.AuthNaming.AuthRoleNaming.ADMIN;
 import static edu.harvard.hms.dbmi.avillach.auth.utils.AuthNaming.AuthRoleNaming.SUPER_ADMIN;
 
 /**
@@ -21,6 +24,7 @@ import static edu.harvard.hms.dbmi.avillach.auth.utils.AuthNaming.AuthRoleNaming
  * <p>Note: Only users with the super admin role can access this endpoint.</p>
  */
 @Controller
+@RequestMapping("/studyAccess")
 public class StudyAccessController {
 
     private final StudyAccessService studyAccessService;
@@ -33,7 +37,7 @@ public class StudyAccessController {
     @Operation(description = "POST a single study and it creates the role, privs, and rules for it, requires SUPER_ADMIN role")
     @Transactional
     @PostMapping(consumes = "application/json")
-    @Secured(SUPER_ADMIN)
+    @RolesAllowed({SUPER_ADMIN})
     public ResponseEntity<String> addStudyAccess(@Parameter(description = "The Study Identifier of the new study from the metadata.json")
                                             @RequestBody String studyIdentifier) {
         String status = studyAccessService.addStudyAccess(studyIdentifier);


### PR DESCRIPTION
[ALS-6103] Added 'RolesAllowed' and 'RequestMapping' annotations to the StudyAccessController. The 'RolesAllowed' annotation replaces the 'Secured' one to specify authorized roles. The 'RequestMapping' annotation is added to specify the path for accessing study data.