### PR TITLE
[ALS-6665] Standardize PIC-SURE's authorization refresh to follow best practices

### DIFF
--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/config/CustomLogoutHandler.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/config/CustomLogoutHandler.java
@@ -1,0 +1,43 @@
+package edu.harvard.hms.dbmi.avillach.auth.config;
+
+import edu.harvard.hms.dbmi.avillach.auth.model.CustomUserDetails;
+import edu.harvard.hms.dbmi.avillach.auth.service.impl.AccessRuleService;
+import edu.harvard.hms.dbmi.avillach.auth.service.impl.SessionService;
+import edu.harvard.hms.dbmi.avillach.auth.service.impl.UserService;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.logout.LogoutHandler;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CustomLogoutHandler implements LogoutHandler {
+
+    private final Logger logger = LoggerFactory.getLogger(CustomLogoutHandler.class);
+    private final SessionService sessionService;
+    private final UserService userService;
+    private final AccessRuleService accessRuleService;
+
+    public CustomLogoutHandler(SessionService sessionService, UserService userService, AccessRuleService accessRuleService) {
+        this.sessionService = sessionService;
+        this.userService = userService;
+        this.accessRuleService = accessRuleService;
+    }
+
+    @Override
+    public void logout(HttpServletRequest request, HttpServletResponse response, Authentication authentication) {
+        Object principal = authentication.getPrincipal();
+
+        if (!(principal instanceof CustomUserDetails customUserDetails)) {
+            logger.error("logout() Principal is not an instance of User.");
+        } else {
+            logger.info("logout() Logging out User: {}", customUserDetails.getUsername());
+            this.sessionService.endSession(customUserDetails.getUsername());
+            this.userService.evictFromCache(customUserDetails.getUsername());
+            this.accessRuleService.evictFromCache(customUserDetails.getUsername());
+        }
+    }
+}
+

--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/rest/AuthenticationController.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/rest/AuthenticationController.java
@@ -2,6 +2,7 @@ package edu.harvard.hms.dbmi.avillach.auth.rest;
 
 import edu.harvard.hms.dbmi.avillach.auth.model.response.PICSUREResponse;
 import edu.harvard.hms.dbmi.avillach.auth.service.AuthenticationService;
+import edu.harvard.hms.dbmi.avillach.auth.service.impl.SessionService;
 import edu.harvard.hms.dbmi.avillach.auth.service.impl.authentication.AuthenticationServiceRegistry;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -33,10 +34,12 @@ public class AuthenticationController {
     private final static Logger logger = LoggerFactory.getLogger(AuthenticationController.class.getName());
 
     private final AuthenticationServiceRegistry authenticationServiceRegistry;
+    private final SessionService sessionService;
 
     @Autowired
-    public AuthenticationController(AuthenticationServiceRegistry authenticationServiceRegistry) {
+    public AuthenticationController(AuthenticationServiceRegistry authenticationServiceRegistry, SessionService sessionService) {
         this.authenticationServiceRegistry = authenticationServiceRegistry;
+        this.sessionService = sessionService;
     }
 
     @Operation(description = "The authentication endpoint for retrieving a valid user token")
@@ -61,6 +64,13 @@ public class AuthenticationController {
 
         HashMap<String, String> authenticate = authenticationService.authenticate(authRequest, request.getServerName());
         if (authenticate != null && !authenticate.isEmpty()) {
+            if (authenticate.containsKey("userId")) {
+                sessionService.startSession(authenticate.get("userId"));
+            } else {
+                logger.error("authentication() userId authentication is null");
+                logger.error("User claims must contain a userId to start their session.");
+                return PICSUREResponse.unauthorizedError("User not authenticated.");
+            }
             logger.info("authentication() User authenticated successfully.");
             return PICSUREResponse.success(authenticate);
         }

--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/SessionService.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/SessionService.java
@@ -1,0 +1,53 @@
+package edu.harvard.hms.dbmi.avillach.auth.service.impl;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.CachePut;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+public class SessionService {
+
+    private final long sessionMaxDuration;
+    private final CacheManager cacheManager;
+
+    public SessionService(@Value("${application.max.session.length}") long sessionMaxDuration, CacheManager cacheManager) {
+        this.sessionMaxDuration = sessionMaxDuration > 0 ? sessionMaxDuration : 8 * 60 * 60 * 1000; // 8 hours in milliseconds
+        this.cacheManager = cacheManager;
+    }
+
+    @CachePut(value = "sessions")
+    public long startSession(String userSubject) {
+        return System.currentTimeMillis();
+    }
+
+    @CacheEvict(value = "sessions")
+    public void endSession(String userSubject) {
+    }
+
+    public Optional<Long> getCachedSessionStartTime(String userSubject) {
+        Cache cache = cacheManager.getCache("sessions");
+        if (cache != null) {
+            Cache.ValueWrapper valueWrapper = cache.get(userSubject);
+            if (valueWrapper != null) {
+                return Optional.ofNullable((Long) valueWrapper.get());
+            }
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * If the user has been logged in longer than the max session duration.
+     * @param userSubject User::getSubject()
+     * @return boolean if the session exists or the length of the current session
+    */
+    public boolean isSessionExpired(String userSubject) {
+        Optional<Long> sessionStartTime = getCachedSessionStartTime(userSubject);
+        return sessionStartTime.map(aLong -> System.currentTimeMillis() - aLong > sessionMaxDuration).orElse(true);
+    }
+
+}

--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/SessionService.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/SessionService.java
@@ -29,7 +29,7 @@ public class SessionService {
     public void endSession(String userSubject) {
     }
 
-    public Optional<Long> getCachedSessionStartTime(String userSubject) {
+    private Optional<Long> getCachedSessionStartTime(String userSubject) {
         Cache cache = cacheManager.getCache("sessions");
         if (cache != null) {
             Cache.ValueWrapper valueWrapper = cache.get(userSubject);

--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/TokenService.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/TokenService.java
@@ -192,6 +192,24 @@ public class TokenService {
                 roles.add(p.getName());
             }
             tokenInspection.addField("roles", String.join(",", roles));
+
+            // Refresh Token
+            Date expiration = jws.getPayload().getExpiration();
+            if (jwtUtil.shouldRefreshToken(expiration, tokenExpirationTime)) {
+                Map<String, String> refreshResponse = refreshToken(token);
+                if (refreshResponse.containsKey("token")) {
+                    tokenInspection.addField("token", refreshResponse.get("token"));
+                    tokenInspection.addField("tokenRefreshed", true);
+                }
+
+                if (refreshResponse.containsKey("error")) {
+                    tokenInspection.setMessage(refreshResponse.get("error"));
+                    tokenInspection.addField("active", false);
+                    return tokenInspection;
+                }
+            } else {
+                tokenInspection.addField("tokenRefreshed", false);
+            }
         } else {
             tokenInspection.setMessage(errorMsg);
             return tokenInspection;

--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/TokenService.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/TokenService.java
@@ -258,8 +258,8 @@ public class TokenService {
         }
 
         if (!JWTUtil.isLongTermToken(claims.getSubject()) && sessionService.isSessionExpired(claims.getSubject())) {
-            logger.info("refreshToken() The user has just is being logged out.");
-            return Map.of("error", "Inner application error, try again or contact admin.");
+            logger.info("refreshToken() The user has just is being logged out. The user's session has expired.");
+            return Map.of("error", "Your session has expired. Please log in again.");
         }
 
         Date expirationDate = new Date(Calendar.getInstance().getTimeInMillis() + this.tokenExpirationTime);

--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/UserService.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/UserService.java
@@ -73,11 +73,12 @@ public class UserService {
         this.connectionRepository = connectionRepository;
         this.roleService = roleService;
         this.tokenExpirationTime = tokenExpirationTime > 0 ? tokenExpirationTime : defaultTokenExpirationTime;
+        logger.info("Token Expiration Time : {}", tokenExpirationTime);
         this.applicationRepository = applicationRepository;
         this.applicationUUID = applicationUUID;
         this.jwtUtil = jwtUtil;
 
-        long defaultLongTermTokenExpirationTime = 1000L * 60 * 60 * 24 * 30; //
+        long defaultLongTermTokenExpirationTime = 1000L * 60 * 60 * 24 * 30;
         this.longTermTokenExpirationTime = longTermTokenExpirationTime > 0 ? longTermTokenExpirationTime : defaultLongTermTokenExpirationTime;
     }
 

--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/authentication/FENCEAuthenticationService.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/authentication/FENCEAuthenticationService.java
@@ -14,13 +14,12 @@ import edu.harvard.hms.dbmi.avillach.auth.service.impl.*;
 import edu.harvard.hms.dbmi.avillach.auth.service.impl.AccessRuleService;
 import edu.harvard.hms.dbmi.avillach.auth.utils.FenceMappingUtility;
 import edu.harvard.hms.dbmi.avillach.auth.utils.RestClientUtil;
+import jakarta.annotation.PostConstruct;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.context.event.ContextRefreshedEvent;
-import org.springframework.context.event.EventListener;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
@@ -79,44 +78,11 @@ public class FENCEAuthenticationService implements AuthenticationService {
         this.isFenceEnabled = isFenceEnabled;
     }
 
-    @EventListener(ContextRefreshedEvent.class)
+    @PostConstruct
     public void initializeFenceService() {
         fenceConnection = connectionService.getConnectionByLabel("FENCE");
-
-        // log all the properties
         logger.info("isFenceEnabled: {}", isFenceEnabled);
         logger.info("idp_provider_uri: {}", idp_provider_uri);
-
-        if (fenceMappingUtility.getFENCEMapping() != null && fenceMappingUtility.getFenceMappingByAuthZ() != null
-                && !fenceMappingUtility.getFENCEMapping().isEmpty() && !fenceMappingUtility.getFenceMappingByAuthZ().isEmpty()) {
-            // Create all potential access rules using the fence mapping
-            Set<Role> roles = fenceMappingUtility.getFenceMappingByAuthZ().values().parallelStream().map(projectMetadata -> {
-                if (projectMetadata == null) {
-                    logger.error("initializeFenceService() -> createAndUpsertRole could not find study in FENCE mapping SKIPPING: {}", projectMetadata);
-                    return null;
-                }
-
-                if (projectMetadata.getStudyIdentifier() == null || projectMetadata.getStudyIdentifier().isEmpty()) {
-                    logger.error("initializeFenceService() -> createAndUpsertRole could not find study identifier in FENCE mapping SKIPPING: {}", projectMetadata);
-                    return null;
-                }
-
-                if (projectMetadata.getAuthZ() == null || projectMetadata.getAuthZ().isEmpty()) {
-                    logger.error("initializeFenceService() -> createAndUpsertRole could not find authZ in FENCE mapping SKIPPING: {}", projectMetadata);
-                    return null;
-                }
-
-                String projectId = projectMetadata.getStudyIdentifier();
-                String consentCode = projectMetadata.getConsentGroupCode();
-                String newRoleName = StringUtils.isNotBlank(consentCode) ? "MANAGED_" + projectId + "_" + consentCode : "MANAGED_" + projectId;
-
-                return this.roleService.createRole(newRoleName, "MANAGED role " + newRoleName);
-            }).filter(Objects::nonNull).collect(Collectors.toSet());
-
-            roleService.persistAll(roles);
-        } else {
-            logger.error("initializeFenceService() -> createAndUpsertRole could not find any studies in FENCE mapping");
-        }
     }
 
     @Override
@@ -175,7 +141,6 @@ public class FENCEAuthenticationService implements AuthenticationService {
         // Update the user's roles (or create them if none exists)
         Iterator<String> project_access_names = fence_user_profile.get("authz").fieldNames();
 
-        // I want to parallelize this, but I'm not sure if it's safe to do so.
         Set<String> roleNames = new HashSet<>();
         project_access_names.forEachRemaining(roleName -> {
             // We need to add/remove the users roles based on what is in the project_access_names list
@@ -192,12 +157,7 @@ public class FENCEAuthenticationService implements AuthenticationService {
             roleNames.add(newRoleName);
         });
 
-        // convert roles to string list
-        String roles = current_user.getRoles().stream().map(Role::getName).collect(Collectors.joining(","));
-        logger.info("Current User Roles: " + roles);
-
         // find roles that are in the user's roles but not in the project_access_names. These are the roles that need to be removed.
-        // exclude userRole -> "PIC-SURE Top Admin".equals(userRole.getName()) || "Admin".equals(userRole.getName()) || userRole.getName().startsWith("MANUAL_")
         Set<Role> rolesToRemove = current_user.getRoles().parallelStream()
                 .filter(role -> !roleNames.contains(role.getName()) && !role.getName().equals(fence_open_access_role_name) && !role.getName().startsWith("MANUAL_") && !role.getName().equals("PIC-SURE Top Admin") && !role.getName().equals("Admin"))
                 .collect(Collectors.toSet());

--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/authorization/AuthorizationService.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/authorization/AuthorizationService.java
@@ -8,6 +8,8 @@ import edu.harvard.hms.dbmi.avillach.auth.entity.Privilege;
 import edu.harvard.hms.dbmi.avillach.auth.entity.User;
 import edu.harvard.hms.dbmi.avillach.auth.rest.TokenController;
 import edu.harvard.hms.dbmi.avillach.auth.service.impl.AccessRuleService;
+import edu.harvard.hms.dbmi.avillach.auth.service.impl.SessionService;
+import io.micrometer.common.util.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -41,6 +43,7 @@ public class AuthorizationService {
     private final Logger logger = LoggerFactory.getLogger(AuthorizationService.class);
 
     protected AccessRuleService accessRuleService;
+    protected SessionService sessionService;
 
     /**
      * Applications that have strict access control. If the application is strict a user must have both privileges and access rules.
@@ -48,12 +51,12 @@ public class AuthorizationService {
      */
     private final Set<String> strictConnections = new HashSet<>();
 
-    public AuthorizationService() {
-    }
-
     @Autowired
-    public AuthorizationService(AccessRuleService accessRuleService, @Value("${strict.authorization.applications.connections}") String strictConnections) {
+    public AuthorizationService(AccessRuleService accessRuleService,
+                                SessionService sessionService,
+                                @Value("${strict.authorization.applications.connections}") String strictConnections) {
         this.accessRuleService = accessRuleService;
+        this.sessionService = sessionService;
         if (strictConnections != null && !strictConnections.isEmpty()) {
             this.strictConnections.addAll(Arrays.asList(strictConnections.split(",")));
         }
@@ -86,10 +89,24 @@ public class AuthorizationService {
      * @see AccessRule
      */
     public boolean isAuthorized(Application application, Object requestBody, User user) {
-        // create timer
         String applicationName = application.getName();
         String resourceId = "null";
         String targetService = "null";
+
+        if (user == null) {
+            logger.error("isAuthorized() User cannot be null");
+            return false;
+        }
+
+        if (StringUtils.isBlank(user.getSubject())) {
+            logger.error("isAuthorized() Subject cannot be blank {}", user.getSubject());
+            return false;
+        }
+
+        if (sessionService.isSessionExpired(user.getSubject())) {
+            logger.error("isAuthorized() Session expired {}", user.getSubject());
+            return false;
+        }
 
         //in some cases, we don't go through the evaluation
         if (requestBody == null) {

--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/utils/JWTUtil.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/utils/JWTUtil.java
@@ -40,10 +40,6 @@ public class JWTUtil {
         this.clientSecretIsBase64 = clientSecretIsBase64;
     }
 
-    public static boolean isLongTermToken(String sub) {
-        return sub.startsWith(AuthNaming.LONG_TERM_TOKEN_PREFIX);
-    }
-
     private String getDecodedClientSecret() {
         if (clientSecretIsBase64) {
             return new String(Base64.decodeBase64(clientSecret));
@@ -123,6 +119,10 @@ public class JWTUtil {
         return Optional.of(authorizationHeader.substring("Bearer".length()).trim());
     }
 
+    public static boolean isLongTermToken(String sub) {
+        return sub.startsWith(AuthNaming.LONG_TERM_TOKEN_PREFIX);
+    }
+
     public String setClientSecret(String clientSecret) {
         return clientSecret;
     }
@@ -131,5 +131,14 @@ public class JWTUtil {
         return clientSecretIsBase64;
     }
 
+    public boolean shouldRefreshToken(Date expiration, long tokenExpirationTime) {
+        long currentTime = System.currentTimeMillis();
+        if (currentTime >= expiration.getTime()) {
+            return false;
+        }
 
+        long halfExpirationTime = tokenExpirationTime / 2;
+        long refreshTime = expiration.getTime() - halfExpirationTime;
+        return currentTime >= refreshTime;
+    }
 }

--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/utils/JWTUtil.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/utils/JWTUtil.java
@@ -40,6 +40,10 @@ public class JWTUtil {
         this.clientSecretIsBase64 = clientSecretIsBase64;
     }
 
+    public static boolean isLongTermToken(String sub) {
+        return sub.startsWith(AuthNaming.LONG_TERM_TOKEN_PREFIX);
+    }
+
     private String getDecodedClientSecret() {
         if (clientSecretIsBase64) {
             return new String(Base64.decodeBase64(clientSecret));

--- a/pic-sure-auth-services/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/pic-sure-auth-services/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -169,5 +169,10 @@
       "name": "a4.okta.idp.provider.uri",
       "type": "java.lang.String",
       "description": "Description for a4.okta.idp.provider.uri."
+    },
+    {
+      "name": "application.max.session.length",
+      "type": "java.lang.String",
+      "description": "If a user has been signed in for this length of time they will be logged out."
     }
   ] }

--- a/pic-sure-auth-services/src/main/resources/application.properties
+++ b/pic-sure-auth-services/src/main/resources/application.properties
@@ -60,8 +60,10 @@ application.client.secret.base64=${APPLICATION_CLIENT_SECRET_IS_BASE_64:false}
 application.user.id.claim=${USER_ID_CLAIM:sub}
 
 # Token Expiration
-# 1 hour in milliseconds
-application.token.expiration.time=${TOKEN_EXPIRATION_TIME:3600000}
+# 15 minutes in milliseconds
+# TODO: (Revert) Temporarily setting token timeout to 5 minutes for testing
+application.token.expiration.time=${TOKEN_EXPIRATION_TIME:300000}
+application.max.session.length=${MAX_SESSION_TIME:600000}
 
 # 30 days in milliseconds
 application.long.term.token.expiration.time=${LONG_TERM_TOKEN_EXPIRATION_TIME:2592000000}

--- a/pic-sure-auth-services/src/main/resources/application.properties
+++ b/pic-sure-auth-services/src/main/resources/application.properties
@@ -60,13 +60,13 @@ application.client.secret.base64=${APPLICATION_CLIENT_SECRET_IS_BASE_64:false}
 application.user.id.claim=${USER_ID_CLAIM:sub}
 
 # Token Expiration
-#application.token.expiration.time=${TOKEN_EXPIRATION_TIME:300000}
-#application.max.session.length=${MAX_SESSION_TIME:600000}
+application.token.expiration.time=${TOKEN_EXPIRATION_TIME:300000}
+application.max.session.length=${MAX_SESSION_TIME:600000}
 
 # IDLE Timeout 15 minutes by default
-application.token.expiration.time=${TOKEN_EXPIRATION_TIME:900000}
+#application.token.expiration.time=${TOKEN_EXPIRATION_TIME:900000}
 # Max session length 8 hours by default
-application.max.session.length=${MAX_SESSION_TIME:28800000}
+#application.max.session.length=${MAX_SESSION_TIME:28800000}
 
 # 30 days in milliseconds
 application.long.term.token.expiration.time=${LONG_TERM_TOKEN_EXPIRATION_TIME:2592000000}

--- a/pic-sure-auth-services/src/main/resources/application.properties
+++ b/pic-sure-auth-services/src/main/resources/application.properties
@@ -60,10 +60,13 @@ application.client.secret.base64=${APPLICATION_CLIENT_SECRET_IS_BASE_64:false}
 application.user.id.claim=${USER_ID_CLAIM:sub}
 
 # Token Expiration
-# 15 minutes in milliseconds
-# TODO: (Revert) Temporarily setting token timeout to 5 minutes for testing
-application.token.expiration.time=${TOKEN_EXPIRATION_TIME:300000}
-application.max.session.length=${MAX_SESSION_TIME:600000}
+#application.token.expiration.time=${TOKEN_EXPIRATION_TIME:300000}
+#application.max.session.length=${MAX_SESSION_TIME:600000}
+
+# IDLE Timeout 15 minutes by default
+application.token.expiration.time=${TOKEN_EXPIRATION_TIME:900000}
+# Max session length 8 hours by default
+application.max.session.length=${MAX_SESSION_TIME:28800000}
 
 # 30 days in milliseconds
 application.long.term.token.expiration.time=${LONG_TERM_TOKEN_EXPIRATION_TIME:2592000000}

--- a/pic-sure-auth-services/src/main/resources/application.properties
+++ b/pic-sure-auth-services/src/main/resources/application.properties
@@ -60,13 +60,13 @@ application.client.secret.base64=${APPLICATION_CLIENT_SECRET_IS_BASE_64:false}
 application.user.id.claim=${USER_ID_CLAIM:sub}
 
 # Token Expiration
-application.token.expiration.time=${TOKEN_EXPIRATION_TIME:300000}
-application.max.session.length=${MAX_SESSION_TIME:600000}
+#application.token.expiration.time=${TOKEN_EXPIRATION_TIME:300000}
+#application.max.session.length=${MAX_SESSION_TIME:600000}
 
 # IDLE Timeout 15 minutes by default
-#application.token.expiration.time=${TOKEN_EXPIRATION_TIME:900000}
+application.token.expiration.time=${TOKEN_EXPIRATION_TIME:900000}
 # Max session length 8 hours by default
-#application.max.session.length=${MAX_SESSION_TIME:28800000}
+application.max.session.length=${MAX_SESSION_TIME:28800000}
 
 # 30 days in milliseconds
 application.long.term.token.expiration.time=${LONG_TERM_TOKEN_EXPIRATION_TIME:2592000000}

--- a/pic-sure-auth-services/src/test/java/edu/harvard/hms/dbmi/avillach/AuthorizationServiceTestByUseCases.java
+++ b/pic-sure-auth-services/src/test/java/edu/harvard/hms/dbmi/avillach/AuthorizationServiceTestByUseCases.java
@@ -3,6 +3,7 @@ package edu.harvard.hms.dbmi.avillach;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import edu.harvard.hms.dbmi.avillach.auth.entity.AccessRule;
 import edu.harvard.hms.dbmi.avillach.auth.repository.AccessRuleRepository;
+import edu.harvard.hms.dbmi.avillach.auth.service.impl.SessionService;
 import edu.harvard.hms.dbmi.avillach.auth.service.impl.authorization.AuthorizationService;
 import edu.harvard.hms.dbmi.avillach.auth.service.impl.AccessRuleService;
 import org.junit.Assert;
@@ -406,6 +407,10 @@ public class AuthorizationServiceTestByUseCases extends AuthorizationService{
             "  },\n" +
             "  \"resourceCredentials\": {}\n" +
             "}";
+
+    public AuthorizationServiceTestByUseCases(AccessRuleService accessRuleService, SessionService sessionService, String strictConnections) {
+        super(accessRuleService, sessionService, strictConnections);
+    }
 
     @BeforeClass
     public static void init() {

--- a/pic-sure-auth-services/src/test/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/AuthorizationServiceTest.java
+++ b/pic-sure-auth-services/src/test/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/AuthorizationServiceTest.java
@@ -28,6 +28,9 @@ public class AuthorizationServiceTest {
     private AccessRuleService accessRuleService;
 
     @Mock
+    private SessionService sessionService;
+
+    @Mock
     private AccessRuleRepository accessRuleRepository;
 
     @Before
@@ -36,7 +39,7 @@ public class AuthorizationServiceTest {
         SecurityContextHolder.setContext(securityContext);
 
         accessRuleService = new AccessRuleService(accessRuleRepository, "false", "false", "false", "false","false", "false");
-        authorizationService = new AuthorizationService(accessRuleService, "fence,okta,open");
+        authorizationService = new AuthorizationService(accessRuleService, sessionService, "fence,okta,open");
     }
 
     @Test

--- a/pic-sure-auth-services/src/test/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/authorization/AuthorizationServiceTest.java
+++ b/pic-sure-auth-services/src/test/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/authorization/AuthorizationServiceTest.java
@@ -6,6 +6,7 @@ import edu.harvard.hms.dbmi.avillach.auth.enums.SecurityRoles;
 import edu.harvard.hms.dbmi.avillach.auth.model.CustomUserDetails;
 import edu.harvard.hms.dbmi.avillach.auth.repository.AccessRuleRepository;
 import edu.harvard.hms.dbmi.avillach.auth.service.impl.AccessRuleService;
+import edu.harvard.hms.dbmi.avillach.auth.service.impl.SessionService;
 import edu.harvard.hms.dbmi.avillach.auth.utils.AuthNaming;
 import org.junit.Assert;
 import org.junit.Before;
@@ -31,6 +32,9 @@ public class AuthorizationServiceTest {
     private AuthorizationService authorizationService;
 
     private AccessRuleService accessRuleService;
+
+    @Mock
+    private SessionService sessionService;
 
     @Mock
     private AccessRuleRepository accessRuleRepository;
@@ -312,8 +316,9 @@ public class AuthorizationServiceTest {
         MockitoAnnotations.initMocks(this);
         SecurityContextHolder.setContext(securityContext);
 
+        when(sessionService.isSessionExpired(any(String.class))).thenReturn(false);
         accessRuleService = new AccessRuleService(accessRuleRepository, "false", "false", "false", "false","false", "false");
-        authorizationService = new AuthorizationService(accessRuleService, "fence,okta");
+        authorizationService = new AuthorizationService(accessRuleService, sessionService, "fence,okta");
     }
 
     @Test

--- a/pic-sure-auth-services/src/test/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/authorization/AuthorizationServiceTestByUseCases.java
+++ b/pic-sure-auth-services/src/test/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/authorization/AuthorizationServiceTestByUseCases.java
@@ -40,11 +40,9 @@ import java.util.UUID;
  * We also have a class testing from the aspect of design, which means each test case is just testing one feature.
  * @see AuthorizationServiceTest
  */
-public class AuthorizationServiceTestByUseCases extends AuthorizationService {
-
+public class AuthorizationServiceTestByUseCases {
 
     ObjectMapper mapper = new ObjectMapper();
-
 
     private static AccessRule rule_caseA;
     private static AccessRule rule_caseB;
@@ -53,8 +51,6 @@ public class AuthorizationServiceTestByUseCases extends AuthorizationService {
     private static AccessRule rule_caseE;
     private static AccessRule rule_caseE_2;
     private static AccessRule rule_caseF;
-
-
 
     private static AccessRule AR_CategoryFilter_String_contains;
     private static AccessRule AR_CategoryFilter_Array_Contains;
@@ -405,6 +401,8 @@ public class AuthorizationServiceTestByUseCases extends AuthorizationService {
             "  },\n" +
             "  \"resourceCredentials\": {}\n" +
             "}";
+
+    private AccessRuleService  accessRuleService;
 
     @BeforeClass
     public static void init() {


### PR DESCRIPTION
#### Standardize PIC-SURE's Authorization Refresh to Follow Best Practices
- Created a new `SessionService` class to track a user's session length and invalidate a user's current session. The `SessionService` includes the following public methods: `startSession`, `endSession`, and `isSessionExpired`.
    - **`startSession`**: Initiates a user's session upon successful login. The `@CachePut` annotation ensures that the user's session is reset even if a current session already exists in the cache.
    - **`endSession`**: Ends a user's session, forcing the user to be logged out.
    - **`isSessionExpired`**: Determines if a user's session is expired. A session is considered expired if it does not exist or if its length exceeds the maximum session length. This method is called during token introspection and token refresh to verify that the user's session is still valid.
    
#### Role creation refactor
- Migrated Fence Mapping role creation from the FENCEAuthorizationService to the RoleService.