### PR TITLE
Update redirect URIs in authentication services

### DIFF
--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/TokenService.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/TokenService.java
@@ -174,7 +174,7 @@ public class TokenService {
                 // The protocol between applications and PSAMA is application will
                 // attach everything that needs to be verified in request field of inputMap
                 // besides token. So here we should attach everything in request.
-                && authorizationService.isAuthorized(application, inputMap.get("request"), user)) {
+                && authorizationService.isAuthorized(application, inputMap.get("request"), user, isLongTermToken)) {
             isAuthorizationPassed = true;
         } else {
             // if isLongTermTokenCompromised flag is true,

--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/authorization/AuthorizationService.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/authorization/AuthorizationService.java
@@ -84,11 +84,12 @@ public class AuthorizationService {
      *
      * @param application
      * @param requestBody
+     * @param isLongTermToken
      * @return
      * @see Privilege
      * @see AccessRule
      */
-    public boolean isAuthorized(Application application, Object requestBody, User user) {
+    public boolean isAuthorized(Application application, Object requestBody, User user, boolean isLongTermToken) {
         String applicationName = application.getName();
         String resourceId = "null";
         String targetService = "null";
@@ -103,7 +104,7 @@ public class AuthorizationService {
             return false;
         }
 
-        if (sessionService.isSessionExpired(user.getSubject())) {
+        if (!isLongTermToken && sessionService.isSessionExpired(user.getSubject())) {
             logger.error("isAuthorized() Session expired {}", user.getSubject());
             return false;
         }

--- a/pic-sure-auth-services/src/test/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/AuthorizationServiceTest.java
+++ b/pic-sure-auth-services/src/test/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/AuthorizationServiceTest.java
@@ -63,7 +63,7 @@ public class AuthorizationServiceTest {
         Map<String, Object> requestBody = new HashMap<>();
         requestBody.put("test", "value");
 
-        boolean result = authorizationService.isAuthorized(application, requestBody, user);
+        boolean result = authorizationService.isAuthorized(application, requestBody, user, false);
 
         assertTrue(result);
     }
@@ -77,7 +77,7 @@ public class AuthorizationServiceTest {
         Map<String, Object> requestBody = new HashMap<>();
         requestBody.put("test", "differentValue");
 
-        boolean result = authorizationService.isAuthorized(application, requestBody, user);
+        boolean result = authorizationService.isAuthorized(application, requestBody, user, false);
 
         assertFalse(result);
     }
@@ -171,7 +171,7 @@ public class AuthorizationServiceTest {
         configureUserSecurityContext(user);
         application.setPrivileges(user.getPrivilegesByApplication(application));
 
-        boolean result = authorizationService.isAuthorized(application, null, user);
+        boolean result = authorizationService.isAuthorized(application, null, user, false);
 
         assertTrue(result);
     }
@@ -182,7 +182,7 @@ public class AuthorizationServiceTest {
         User user = createTestUser();
 
         user.getRoles().iterator().next().setPrivileges(Collections.emptySet());
-        boolean result = authorizationService.isAuthorized(application, new HashMap<>(), user);
+        boolean result = authorizationService.isAuthorized(application, new HashMap<>(), user, false);
 
         assertFalse(result);
     }

--- a/pic-sure-auth-services/src/test/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/authorization/AuthorizationServiceTest.java
+++ b/pic-sure-auth-services/src/test/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/authorization/AuthorizationServiceTest.java
@@ -344,7 +344,7 @@ public class AuthorizationServiceTest {
         Map<String, Object> requestBody = new HashMap<>();
         requestBody.put("test", "value");
 
-        boolean result = authorizationService.isAuthorized(application, requestBody, user);
+        boolean result = authorizationService.isAuthorized(application, requestBody, user, false);
 
         assertTrue(result);
     }
@@ -359,7 +359,7 @@ public class AuthorizationServiceTest {
         Map<String, Object> requestBody = new HashMap<>();
         requestBody.put("test", "differentValue");
 
-        boolean result = authorizationService.isAuthorized(application, requestBody, user);
+        boolean result = authorizationService.isAuthorized(application, requestBody, user, false);
 
         assertFalse(result);
     }
@@ -374,7 +374,7 @@ public class AuthorizationServiceTest {
         Map<String, Object> requestBody = new HashMap<>();
         requestBody.put("test", "differentValue");
 
-        boolean result = authorizationService.isAuthorized(application, requestBody, user);
+        boolean result = authorizationService.isAuthorized(application, requestBody, user, false);
 
         assertFalse(result);
     }
@@ -476,7 +476,7 @@ public class AuthorizationServiceTest {
         configureUserSecurityContext(user);
         application.setPrivileges(user.getPrivilegesByApplication(application));
 
-        boolean result = authorizationService.isAuthorized(application, null, user);
+        boolean result = authorizationService.isAuthorized(application, null, user, false);
 
         assertTrue(result);
     }
@@ -488,7 +488,7 @@ public class AuthorizationServiceTest {
         user.setConnection(createFenceTestConnection());
 
         user.getRoles().iterator().next().setPrivileges(Collections.emptySet());
-        boolean result = authorizationService.isAuthorized(application, new HashMap<>(), user);
+        boolean result = authorizationService.isAuthorized(application, new HashMap<>(), user, false);
 
         assertFalse(result);
     }


### PR DESCRIPTION
This commit adds a new parameter `isLongTermToken` to the `isAuthorized` method in the `AuthorizationService` class. It updates the `TokenService` and several test cases to accommodate this change, ensuring that long-term tokens bypass the session expiration check.