### PR TITLE
Add logout endpoint and improve token validation

### DIFF
--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/config/CustomLogoutHandler.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/config/CustomLogoutHandler.java
@@ -33,7 +33,15 @@ public class CustomLogoutHandler implements LogoutHandler {
     @Override
     public void logout(HttpServletRequest request, HttpServletResponse response, Authentication authentication) {
         String bearer = request.getHeader("Authorization");
+        if (!bearer.startsWith("Bearer ")) {
+            return;
+        }
+
         String token = bearer.substring(7);
+        if (StringUtils.isBlank(token)) {
+            return;
+        }
+
         Claims payload = jwtUtil.parseToken(token).getPayload();
         String subject = payload.getSubject();
 

--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/config/SecurityConfig.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/config/SecurityConfig.java
@@ -60,7 +60,8 @@ public class SecurityConfig {
                                     "/swagger.json",
                                     "/user/me/queryTemplate",
                                     "/user/me/queryTemplate/**",
-                                    "/open/validate"
+                                    "/open/validate",
+                                    "/logout"
                             ).permitAll()
                             .anyRequest().authenticated()
                 )


### PR DESCRIPTION
Allow the "/logout" endpoint to be accessed without authentication to facilitate user sign-out. Additionally, enhance the logout handler by adding checks for token prefix and blank token to improve robustness.