### PR TITLE
[ALS-7554] User should not be able to search without a valid token

### DIFF
--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/AccessRuleService.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/AccessRuleService.java
@@ -186,7 +186,7 @@ public class AccessRuleService {
         return preProcessARBySortedKeys(accessRules);
     }
 
-    @CacheEvict(value = "preProcessedAccessRules", keyGenerator = "customKeyGenerator")
+    @CacheEvict(value = "preProcessedAccessRules")
     public void evictFromPreProcessedAccessRules(String userSubject) {
         if (userSubject == null || userSubject.isEmpty()) {
             logger.warn("evictFromPreProcessedAccessRules() was called with a null or empty email");

--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/CacheEvictionService.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/CacheEvictionService.java
@@ -1,12 +1,16 @@
 package edu.harvard.hms.dbmi.avillach.auth.service.impl;
 
 import edu.harvard.hms.dbmi.avillach.auth.entity.User;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 @Service
 public class CacheEvictionService {
 
+    private static final Logger log = LoggerFactory.getLogger(CacheEvictionService.class);
     private final SessionService sessionService;
     private final UserService userService;
     private final AccessRuleService accessRuleService;
@@ -26,7 +30,17 @@ public class CacheEvictionService {
     }
 
     public void evictCache(User user) {
+        if (user == null) {
+            log.error("User is null, cannot evict cache");
+            return;
+        }
+
         String userSubject = user.getSubject();
+        if (StringUtils.isBlank(userSubject)) {
+            log.error("User subject is blank, cannot evict cache");
+            return;
+        }
+
         evictCache(userSubject);
     }
 

--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/TokenService.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/TokenService.java
@@ -80,6 +80,7 @@ public class TokenService {
         if (token == null || token.isEmpty()) {
             logger.error("Token - {} is blank", token);
             tokenInspection.setMessage("Token not found");
+            tokenInspection.addField("active", false);
             return tokenInspection;
         }
 
@@ -98,6 +99,7 @@ public class TokenService {
             // only when the token is for sure invalid, we can dump it into the log.
             logger.error("_inspectToken() the token - {} - is invalid with exception: {}", token, ex.getMessage());
             tokenInspection.setMessage(ex.getMessage());
+            tokenInspection.addField("active", false);
             return tokenInspection;
         }
 
@@ -142,6 +144,7 @@ public class TokenService {
         if (user == null) {
             logger.error("_inspectToken() could not find user with subject {}", subject);
             tokenInspection.setMessage("user doesn't exist");
+            tokenInspection.addField("active", false);
             return tokenInspection;
         }
 

--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/authentication/FENCEAuthenticationService.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/authentication/FENCEAuthenticationService.java
@@ -118,7 +118,6 @@ public class FENCEAuthenticationService implements AuthenticationService {
             currentUser = createUserFromFENCEProfile(fence_user_profile);
             logger.info("getFENCEProfile() saved details for user with e-mail:{} and subject:{}", currentUser.getEmail(), currentUser.getSubject());
             cacheEvictionService.evictCache(currentUser);
-
         } catch (Exception ex) {
             logger.error("getFENCEToken() Could not persist the user information, because {}", ex.getMessage());
             throw new NotAuthorizedException("The user details could not be persisted. Please contact the administrator.");


### PR DESCRIPTION
[ALS-7554] User should not be able to search, the dictionary, without a valid token.
- Include a minor caching fix.