### PR TITLE
Refactor role retrieval to return Set instead of Optional

### DIFF
--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/RoleService.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/RoleService.java
@@ -285,13 +285,13 @@ public class RoleService {
         return status;
     }
 
-    public Optional<Set<String>> getRoleNamesForDbgapPermissions(Set<RasDbgapPermission> dbgapPermissions) {
+    public Set<String> getRoleNamesForDbgapPermissions(Set<RasDbgapPermission> dbgapPermissions) {
+        Set<String> roles = new HashSet<>();
         if (dbgapPermissions == null || dbgapPermissions.isEmpty()) {
             logger.info("getRoleNamesForDbgapPermissions() dbgapPermissions is empty");
-            return Optional.empty();
+            return roles;
         }
 
-        Set<String> roles = new HashSet<>();
         dbgapPermissions.forEach(dbgapPermission -> {
             String roleName = StringUtils.isNotBlank(dbgapPermission.getConsentGroup()) ?
                     "MANAGED_" + dbgapPermission.getPhsId() + "_" + dbgapPermission.getConsentGroup() :
@@ -299,7 +299,7 @@ public class RoleService {
             roles.add(roleName);
         });
 
-        return Optional.of(roles);
+        return roles;
     }
 
     public Set<Role> findByNameIn(Set<String> roleNames) {

--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/authentication/RASAuthenticationService.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/authentication/RASAuthenticationService.java
@@ -118,7 +118,7 @@ public class RASAuthenticationService extends OktaAuthenticationService implemen
 
         if (!rasPassport.get().getIss().equals(this.rasPassportIssuer)) {
             logger.error("validateRASPassport() LOGIN FAILED ___ PASSPORT ISSUER IS NOT CORRECT ___ USER: {} ___ " +
-                    "EXPECTED ISSUER {} ___ ACTUAL ISSUER {} ___ CODE {}",
+                         "EXPECTED ISSUER {} ___ ACTUAL ISSUER {} ___ CODE {}",
                     user.getSubject(), this.rasPassportIssuer, rasPassport.get().getIss(), authRequest.get("code"));
             return null;
         }
@@ -126,14 +126,12 @@ public class RASAuthenticationService extends OktaAuthenticationService implemen
         logger.info("RAS PASSPORT FOUND ___ USER: {} ___ PASSPORT: {} ___ CODE {}", user.getSubject(), rasPassport.get(), authRequest.get("code"));
 
         Set<RasDbgapPermission> dbgapPermissions = this.rasPassPortService.ga4gpPassportToRasDbgapPermissions(rasPassport.get().getGa4ghPassportV1());
-        Optional<Set<String>> dbgapRoleNames = this.roleService.getRoleNamesForDbgapPermissions(dbgapPermissions);
-        if (dbgapRoleNames.isPresent()) {
-            user = userService.updateUserRoles(user, dbgapRoleNames.get());
-            logger.debug("USER {} ROLES UPDATED {} ___ CODE {}",
-                    user.getSubject(),
-                    user.getRoles().stream().map(role -> role.getName().replace("MANAGED_", "")).toArray(),
-                    authRequest.get("code"));
-        }
+        Set<String> dbgapRoleNames = this.roleService.getRoleNamesForDbgapPermissions(dbgapPermissions);
+        user = userService.updateUserRoles(user, dbgapRoleNames);
+        logger.debug("USER {} ROLES UPDATED {} ___ CODE {}",
+                user.getSubject(),
+                user.getRoles().stream().map(role -> role.getName().replace("MANAGED_", "")).toArray(),
+                authRequest.get("code"));
 
         String passport = introspectResponse.get("passport_jwt_v11").toString();
         user.setPassport(passport);
@@ -183,7 +181,7 @@ public class RASAuthenticationService extends OktaAuthenticationService implemen
      * Generate the user metadata that will be stored in the database. This metadata is used to determine the user's
      * role and other information.
      *
-     * @param user               The user
+     * @param user The user
      * @return The user metadata as an ObjectNode
      */
     protected ObjectNode generateRasUserMetadata(User user) {

--- a/pic-sure-auth-services/src/test/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/RoleServiceTest.java
+++ b/pic-sure-auth-services/src/test/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/RoleServiceTest.java
@@ -290,7 +290,7 @@ public class RoleServiceTest {
 
     @Test
     public void getRoleNamesForDbgapPermissions_PermissionsAreNull() {
-        Optional<Set<String>> rolesForDbgapPermissions = roleService.getRoleNamesForDbgapPermissions(null);
+        Set<String> rolesForDbgapPermissions = roleService.getRoleNamesForDbgapPermissions(null);
         assertNotNull(rolesForDbgapPermissions);
         assertTrue(rolesForDbgapPermissions.isEmpty());
     }
@@ -298,8 +298,7 @@ public class RoleServiceTest {
     @Test
     public void getRoleNamesForDbgapPermissions_PermissionsEmpty() {
         Set<RasDbgapPermission> rasDbgapPermissions = new HashSet<>();
-
-        Optional<Set<String>> rolesForDbgapPermissions = roleService.getRoleNamesForDbgapPermissions(rasDbgapPermissions);
+        Set<String> rolesForDbgapPermissions = roleService.getRoleNamesForDbgapPermissions(rasDbgapPermissions);
         assertNotNull(rolesForDbgapPermissions);
         assertTrue(rolesForDbgapPermissions.isEmpty());
     }
@@ -330,7 +329,7 @@ public class RoleServiceTest {
         rasDbgapPermissions.add(rasDbgapPermissionV1);
         rasDbgapPermissions.add(rasDbgapPermissionV2);
 
-        Optional<Set<String>> rolesForDbgapPermissions = roleService.getRoleNamesForDbgapPermissions(rasDbgapPermissions);
+        Set<String> rolesForDbgapPermissions = roleService.getRoleNamesForDbgapPermissions(rasDbgapPermissions);
         assertNotNull(rolesForDbgapPermissions);
         System.out.println(rolesForDbgapPermissions);
     }


### PR DESCRIPTION
- **RoleService Update:** Replaced the use of `Optional` with a direct `Set` return for dbGaP role retrieval.
  - **Impact:** This modification ensures that user permissions are correctly updated, particularly in cases where no permissions are assigned by RAS.