### PR TITLE
[ALS-8262] Test User Role Updates On Empty DBGap Passport

### DIFF
--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/filter/JWTFilter.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/filter/JWTFilter.java
@@ -197,10 +197,7 @@ public class JWTFilter extends OncePerRequestFilter {
             }
         }
 
-        // Get the user's roles
         Set<Role> userRoles = authenticatedUser.getUser().getRoles();
-
-        // Check if the user has any roles and privileges associated with them
         if (userRoles == null || userRoles.isEmpty() || userRoles.stream().allMatch(role -> CollectionUtils.isEmpty(role.getPrivileges()))) {
             logger.error("User doesn't have any roles or privileges.");
             try {

--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/authentication/RASAuthenticationService.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/authentication/RASAuthenticationService.java
@@ -106,7 +106,7 @@ public class RASAuthenticationService extends OktaAuthenticationService implemen
         User user = initializedUser.get();
         Optional<Passport> rasPassport = extractAndVerifyPassport(authRequest, introspectResponse, user);
         if (rasPassport.isEmpty()) return null;
-        user = updateUserRoles(authRequest.get("code"), user, rasPassport.get());
+        user = updateRasUserRoles(authRequest.get("code"), user, rasPassport.get());
         setUserPassport(authRequest, introspectResponse, user);
         HashMap<String, String> responseMap = createUserClaims(user, idToken);
 
@@ -140,7 +140,7 @@ public class RASAuthenticationService extends OktaAuthenticationService implemen
         return rasPassport;
     }
 
-    protected User updateUserRoles(String code, User user, Passport rasPassport) {
+    protected User updateRasUserRoles(String code, User user, Passport rasPassport) {
         logger.info("RAS PASSPORT FOUND ___ USER: {} ___ PASSPORT: {} ___ CODE {}", user.getSubject(), rasPassport, code);
         Set<RasDbgapPermission> dbgapPermissions = this.rasPassPortService.ga4gpPassportToRasDbgapPermissions(rasPassport.getGa4ghPassportV1());
         Set<String> dbgapRoleNames = this.roleService.getRoleNamesForDbgapPermissions(dbgapPermissions);

--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/authentication/RASAuthenticationService.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/authentication/RASAuthenticationService.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import edu.harvard.hms.dbmi.avillach.auth.entity.Connection;
-import edu.harvard.hms.dbmi.avillach.auth.entity.Role;
 import edu.harvard.hms.dbmi.avillach.auth.entity.User;
 import edu.harvard.hms.dbmi.avillach.auth.model.ras.Passport;
 import edu.harvard.hms.dbmi.avillach.auth.model.ras.RasDbgapPermission;
@@ -105,39 +104,12 @@ public class RASAuthenticationService extends OktaAuthenticationService implemen
         }
 
         User user = initializedUser.get();
-        Optional<Passport> rasPassport = this.rasPassPortService.extractPassport(introspectResponse);
-        if (rasPassport.isEmpty()) {
-            logger.info("LOGIN FAILED ___ NO RAS PASSPORT FOUND ___ USER: {} ___ CODE {}", user.getSubject(), authRequest.get("code"));
-            return null;
-        }
-
-        if (rasPassPortService.isExpired(rasPassport.get())) {
-            logger.error("validateRASPassport() LOGIN FAILED ___ PASSPORT IS EXPIRED ___ USER: {} ___ CODE {}", user.getSubject(), authRequest.get("code"));
-            return null;
-        }
-
-        if (!rasPassport.get().getIss().equals(this.rasPassportIssuer)) {
-            logger.error("validateRASPassport() LOGIN FAILED ___ PASSPORT ISSUER IS NOT CORRECT ___ USER: {} ___ " +
-                         "EXPECTED ISSUER {} ___ ACTUAL ISSUER {} ___ CODE {}",
-                    user.getSubject(), this.rasPassportIssuer, rasPassport.get().getIss(), authRequest.get("code"));
-            return null;
-        }
-
-        logger.info("RAS PASSPORT FOUND ___ USER: {} ___ PASSPORT: {} ___ CODE {}", user.getSubject(), rasPassport.get(), authRequest.get("code"));
-
-        Set<RasDbgapPermission> dbgapPermissions = this.rasPassPortService.ga4gpPassportToRasDbgapPermissions(rasPassport.get().getGa4ghPassportV1());
-        Set<String> dbgapRoleNames = this.roleService.getRoleNamesForDbgapPermissions(dbgapPermissions);
-        user = userService.updateUserRoles(user, dbgapRoleNames);
-        logger.debug("USER {} ROLES UPDATED {} ___ CODE {}",
-                user.getSubject(),
-                user.getRoles().stream().map(role -> role.getName().replace("MANAGED_", "")).toArray(),
-                authRequest.get("code"));
-
-        String passport = introspectResponse.get("passport_jwt_v11").toString();
-        user.setPassport(passport);
-        logger.info("RAS PASSPORT SUCCESSFULLY ADDED TO USER: {} ___ CODE {}", user.getSubject(), authRequest.get("code"));
-        userService.save(user);
+        Optional<Passport> rasPassport = extractAndVerifyPassport(authRequest, introspectResponse, user);
+        if (rasPassport.isEmpty()) return null;
+        user = updateUserRoles(authRequest.get("code"), user, rasPassport.get());
+        setUserPassport(authRequest, introspectResponse, user);
         HashMap<String, String> responseMap = createUserClaims(user, idToken);
+
         responseMap.put("oktaIdToken", idToken);
         logger.info("LOGIN SUCCESS ___ USER {}:{} ___ WITH ROLES ___ {} ___ AUTHORIZATION WILL EXPIRE AT  ___ {} ___ CODE {}",
                 user.getSubject(), user.getUuid().toString(),
@@ -145,6 +117,39 @@ public class RASAuthenticationService extends OktaAuthenticationService implemen
                 responseMap.get("expirationDate"), authRequest.get("code"));
 
         return responseMap;
+    }
+
+    private Optional<Passport> extractAndVerifyPassport(Map<String, String> authRequest, JsonNode introspectResponse, User user) {
+        Optional<Passport> rasPassport = this.rasPassPortService.extractPassport(introspectResponse);
+        if (rasPassport.isEmpty()) {
+            logger.info("LOGIN FAILED ___ NO RAS PASSPORT FOUND ___ USER: {} ___ CODE {}", user.getSubject(), authRequest.get("code"));
+            return Optional.empty();
+        }
+
+        if (rasPassPortService.isExpired(rasPassport.get())) {
+            logger.error("validateRASPassport() LOGIN FAILED ___ PASSPORT IS EXPIRED ___ USER: {} ___ CODE {}", user.getSubject(), authRequest.get("code"));
+            return Optional.empty();
+        }
+
+        if (!rasPassport.get().getIss().equals(this.rasPassportIssuer)) {
+            logger.error("validateRASPassport() LOGIN FAILED ___ PASSPORT ISSUER IS NOT CORRECT ___ USER: {} ___ " +
+                         "EXPECTED ISSUER {} ___ ACTUAL ISSUER {} ___ CODE {}",
+                    user.getSubject(), this.rasPassportIssuer, rasPassport.get().getIss(), authRequest.get("code"));
+            return Optional.empty();
+        }
+        return rasPassport;
+    }
+
+    protected User updateUserRoles(String code, User user, Passport rasPassport) {
+        logger.info("RAS PASSPORT FOUND ___ USER: {} ___ PASSPORT: {} ___ CODE {}", user.getSubject(), rasPassport, code);
+        Set<RasDbgapPermission> dbgapPermissions = this.rasPassPortService.ga4gpPassportToRasDbgapPermissions(rasPassport.getGa4ghPassportV1());
+        Set<String> dbgapRoleNames = this.roleService.getRoleNamesForDbgapPermissions(dbgapPermissions);
+        user = userService.updateUserRoles(user, dbgapRoleNames);
+        logger.debug("USER {} ROLES UPDATED {} ___ CODE {}",
+                user.getSubject(),
+                user.getRoles().stream().map(role -> role.getName().replace("MANAGED_", "")).toArray(),
+                code);
+        return user;
     }
 
     private Optional<User> initializeUser(JsonNode introspectResponse) {
@@ -197,7 +202,13 @@ public class RASAuthenticationService extends OktaAuthenticationService implemen
 
         return objectNode;
     }
-
+    
+    private void setUserPassport(Map<String, String> authRequest, JsonNode introspectResponse, User user) {
+        String passport = introspectResponse.get("passport_jwt_v11").toString();
+        user.setPassport(passport);
+        userService.save(user);
+        logger.info("RAS PASSPORT SUCCESSFULLY ADDED TO USER: {} ___ CODE {}", user.getSubject(), authRequest.get("code"));
+    }
 
     @Override
     public String getProvider() {
@@ -212,5 +223,6 @@ public class RASAuthenticationService extends OktaAuthenticationService implemen
     public void setRasConnection(Connection rasConnection) {
         this.rasConnection = rasConnection;
     }
+
 
 }

--- a/pic-sure-auth-services/src/test/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/authentication/RASAuthenticationServiceTest.java
+++ b/pic-sure-auth-services/src/test/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/authentication/RASAuthenticationServiceTest.java
@@ -114,7 +114,6 @@ public class RASAuthenticationServiceTest {
         String introspectionResponse =
                 "{\"active\":true,\"sub\":\"example_email@test.com\",\"client_id\":\"test_client_id\",\"passport_jwt_v11\":\""+ exampleRasPassport +"\"}";
         JsonNode introspectionResponseParsed = new ObjectMapper().readTree(introspectionResponse);
-        String code = "AlphaNumericCode";
         User user = createTestUser();
         Optional<Passport> passport = this.rasPassPortService.extractPassport(introspectionResponseParsed);
         assertTrue(passport.isPresent());

--- a/pic-sure-auth-services/src/test/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/authentication/RASAuthenticationServiceTest.java
+++ b/pic-sure-auth-services/src/test/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/authentication/RASAuthenticationServiceTest.java
@@ -1,9 +1,14 @@
 package edu.harvard.hms.dbmi.avillach.auth.service.impl.authentication;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import edu.harvard.hms.dbmi.avillach.auth.entity.Connection;
 import edu.harvard.hms.dbmi.avillach.auth.entity.Privilege;
 import edu.harvard.hms.dbmi.avillach.auth.entity.Role;
 import edu.harvard.hms.dbmi.avillach.auth.entity.User;
+import edu.harvard.hms.dbmi.avillach.auth.model.ras.Passport;
+import edu.harvard.hms.dbmi.avillach.auth.model.ras.RasDbgapPermission;
 import edu.harvard.hms.dbmi.avillach.auth.repository.RoleRepository;
 import edu.harvard.hms.dbmi.avillach.auth.service.impl.*;
 import edu.harvard.hms.dbmi.avillach.auth.utils.FenceMappingUtility;
@@ -19,6 +24,7 @@ import org.springframework.test.context.ContextConfiguration;
 import java.util.*;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.*;
 
 @SpringBootTest
@@ -90,7 +96,6 @@ public class RASAuthenticationServiceTest {
 
         // token exchange
         when(restClientUtil.retrievePostResponse(anyString(), any(), eq(queryString))).thenReturn(ResponseEntity.ok(data));
-
         // introspect
         when(restClientUtil.retrievePostResponse(anyString(), any(), eq(payload))).thenReturn(ResponseEntity.ok(introspectionResponse));
 
@@ -102,6 +107,30 @@ public class RASAuthenticationServiceTest {
         when(userService.updateUserRoles(any(), any())).thenReturn(user);
         HashMap<String, String> authenticate = rasAuthenticationService.authenticate(authRequest, testDomain);
         assertNotNull(authenticate);
+    }
+
+    @Test
+    public void testUpdateUserRoles_withEmptyDBGapPermissions() throws JsonProcessingException {
+        String introspectionResponse =
+                "{\"active\":true,\"sub\":\"example_email@test.com\",\"client_id\":\"test_client_id\",\"passport_jwt_v11\":\""+ exampleRasPassport +"\"}";
+        JsonNode introspectionResponseParsed = new ObjectMapper().readTree(introspectionResponse);
+        String code = "AlphaNumericCode";
+        User user = createTestUser();
+        Optional<Passport> passport = this.rasPassPortService.extractPassport(introspectionResponseParsed);
+        assertTrue(passport.isPresent());
+
+        Set<RasDbgapPermission> dbgapPermissions = new HashSet<>();
+        Set<String> dbgapRoleNames = new HashSet<>();
+
+        when(rasPassPortService.ga4gpPassportToRasDbgapPermissions(any())).thenReturn(dbgapPermissions);
+        when(roleService.getRoleNamesForDbgapPermissions(any())).thenReturn(dbgapRoleNames);
+        when(userService.updateUserRoles(any(), any())).thenReturn(user);
+
+        user = this.rasAuthenticationService.updateRasUserRoles(code, user, passport.get());
+        assertNotNull(user);
+
+        // We are verifying that we attempt to update a users roles even if no dbgap roles are present.
+        verify(userService, times(1)).updateUserRoles(user, dbgapRoleNames);
     }
 
     private User createTestUser() {


### PR DESCRIPTION
Added a unit test that verifies that `roleService.updateUserRoles()` is called when the provided db gap permissions are empty. 