### PR TITLE
Filter expired permissions from RAS Ga4gh Passports

### DIFF
--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/RASPassPortService.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/RASPassPortService.java
@@ -166,12 +166,10 @@ public class RASPassPortService {
 
         logger.debug("Converting ga4ghPassports to RasDbgapPermissions");
         HashSet<RasDbgapPermission> rasDbgapPermissions = new HashSet<>();
-        long date = Instant.now().toEpochMilli();
+        long date = Instant.now().toEpochMilli() / 1000;
         ga4ghPassports.forEach(ga4ghPassport -> {
             if (ga4ghPassport.isPresent()) {
                 Ga4ghPassportV1 ga4ghPassportV1 = ga4ghPassport.get();
-                logger.info("ga4gh_passport_v1: {}", ga4ghPassportV1);
-
                 rasDbgapPermissions.addAll(ga4ghPassportV1.getRasDbgagPermissions().stream().filter(rasDbgapPermission -> date <= rasDbgapPermission.getExpiration()).collect(Collectors.toSet()));
             }
         });

--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/RASPassPortService.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/RASPassPortService.java
@@ -165,12 +165,12 @@ public class RASPassPortService {
 
         logger.debug("Converting ga4ghPassports to RasDbgapPermissions");
         HashSet<RasDbgapPermission> rasDbgapPermissions = new HashSet<>();
+        long date = new Date().toInstant().toEpochMilli();
         ga4ghPassports.forEach(ga4ghPassport -> {
             if (ga4ghPassport.isPresent()) {
                 Ga4ghPassportV1 ga4ghPassportV1 = ga4ghPassport.get();
                 logger.info("ga4gh_passport_v1: {}", ga4ghPassportV1);
 
-                long date = new Date().toInstant().toEpochMilli();
                 rasDbgapPermissions.addAll(ga4ghPassportV1.getRasDbgagPermissions().stream().filter(rasDbgapPermission -> date <= rasDbgapPermission.getExpiration()).collect(Collectors.toSet()));
             }
         });

--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/RASPassPortService.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/RASPassPortService.java
@@ -20,6 +20,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 
+import java.time.Instant;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -165,7 +166,7 @@ public class RASPassPortService {
 
         logger.debug("Converting ga4ghPassports to RasDbgapPermissions");
         HashSet<RasDbgapPermission> rasDbgapPermissions = new HashSet<>();
-        long date = new Date().toInstant().toEpochMilli();
+        long date = Instant.now().toEpochMilli();
         ga4ghPassports.forEach(ga4ghPassport -> {
             if (ga4ghPassport.isPresent()) {
                 Ga4ghPassportV1 ga4ghPassportV1 = ga4ghPassport.get();

--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/authentication/RASAuthenticationService.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/authentication/RASAuthenticationService.java
@@ -145,9 +145,7 @@ public class RASAuthenticationService extends OktaAuthenticationService implemen
     protected User updateRasUserRoles(String code, User user, Passport rasPassport) {
         logger.info("RAS PASSPORT FOUND ___ USER: {} ___ PASSPORT: {} ___ CODE {}", user.getSubject(), rasPassport, code);
         Set<Optional<Ga4ghPassportV1>> ga4ghPassports = rasPassport.getGa4ghPassportV1().stream().map(JWTUtil::parseGa4ghPassportV1).filter(Optional::isPresent).collect(Collectors.toSet());
-        ga4ghPassports.forEach(ga4ghPassport -> logger.info(ga4ghPassport.toString()));
         Set<RasDbgapPermission> dbgapPermissions = this.rasPassPortService.ga4gpPassportToRasDbgapPermissions(ga4ghPassports);
-        dbgapPermissions.forEach(dbgapPermission -> logger.info(dbgapPermission.toString()));
         Set<String> dbgapRoleNames = this.roleService.getRoleNamesForDbgapPermissions(dbgapPermissions);
         user = userService.updateUserRoles(user, dbgapRoleNames);
         logger.debug("USER {} ROLES UPDATED {} ___ CODE {}",

--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/authentication/RASAuthenticationService.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/authentication/RASAuthenticationService.java
@@ -5,10 +5,12 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import edu.harvard.hms.dbmi.avillach.auth.entity.Connection;
 import edu.harvard.hms.dbmi.avillach.auth.entity.User;
+import edu.harvard.hms.dbmi.avillach.auth.model.ras.Ga4ghPassportV1;
 import edu.harvard.hms.dbmi.avillach.auth.model.ras.Passport;
 import edu.harvard.hms.dbmi.avillach.auth.model.ras.RasDbgapPermission;
 import edu.harvard.hms.dbmi.avillach.auth.service.AuthenticationService;
 import edu.harvard.hms.dbmi.avillach.auth.service.impl.*;
+import edu.harvard.hms.dbmi.avillach.auth.utils.JWTUtil;
 import edu.harvard.hms.dbmi.avillach.auth.utils.RestClientUtil;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
@@ -142,7 +144,8 @@ public class RASAuthenticationService extends OktaAuthenticationService implemen
 
     protected User updateRasUserRoles(String code, User user, Passport rasPassport) {
         logger.info("RAS PASSPORT FOUND ___ USER: {} ___ PASSPORT: {} ___ CODE {}", user.getSubject(), rasPassport, code);
-        Set<RasDbgapPermission> dbgapPermissions = this.rasPassPortService.ga4gpPassportToRasDbgapPermissions(rasPassport.getGa4ghPassportV1());
+        Set<Optional<Ga4ghPassportV1>> ga4ghPassports = rasPassport.getGa4ghPassportV1().stream().map(JWTUtil::parseGa4ghPassportV1).filter(Optional::isPresent).collect(Collectors.toSet());
+        Set<RasDbgapPermission> dbgapPermissions = this.rasPassPortService.ga4gpPassportToRasDbgapPermissions(ga4ghPassports);
         Set<String> dbgapRoleNames = this.roleService.getRoleNamesForDbgapPermissions(dbgapPermissions);
         user = userService.updateUserRoles(user, dbgapRoleNames);
         logger.debug("USER {} ROLES UPDATED {} ___ CODE {}",

--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/authentication/RASAuthenticationService.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/authentication/RASAuthenticationService.java
@@ -145,7 +145,9 @@ public class RASAuthenticationService extends OktaAuthenticationService implemen
     protected User updateRasUserRoles(String code, User user, Passport rasPassport) {
         logger.info("RAS PASSPORT FOUND ___ USER: {} ___ PASSPORT: {} ___ CODE {}", user.getSubject(), rasPassport, code);
         Set<Optional<Ga4ghPassportV1>> ga4ghPassports = rasPassport.getGa4ghPassportV1().stream().map(JWTUtil::parseGa4ghPassportV1).filter(Optional::isPresent).collect(Collectors.toSet());
+        ga4ghPassports.forEach(ga4ghPassport -> logger.info(ga4ghPassport.toString()));
         Set<RasDbgapPermission> dbgapPermissions = this.rasPassPortService.ga4gpPassportToRasDbgapPermissions(ga4ghPassports);
+        dbgapPermissions.forEach(dbgapPermission -> logger.info(dbgapPermission.toString()));
         Set<String> dbgapRoleNames = this.roleService.getRoleNamesForDbgapPermissions(dbgapPermissions);
         user = userService.updateUserRoles(user, dbgapRoleNames);
         logger.debug("USER {} ROLES UPDATED {} ___ CODE {}",

--- a/pic-sure-auth-services/src/test/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/RASPassPortServiceTest.java
+++ b/pic-sure-auth-services/src/test/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/RASPassPortServiceTest.java
@@ -14,6 +14,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.ContextConfiguration;
 
+import java.time.Instant;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
@@ -67,7 +68,7 @@ public class RASPassPortServiceTest {
     @Test
     public void testGa4gpPassportStudies_HasCorrectStudies() {
         Optional<Passport> passport = JWTUtil.parsePassportJWTV11(exampleRasPassport);
-        long futureDate = new Date().toInstant().toEpochMilli() + 100000;
+        long futureDate = Instant.now().toEpochMilli() + 100000;
 
         // Update the expiry date of each permission in our test passport. All permissions in the example passport
         // expired in 2022.
@@ -93,8 +94,8 @@ public class RASPassPortServiceTest {
     @Test
     public void testGa4gpPassportStudies_HalfAreExpired() {
         Optional<Passport> passport = JWTUtil.parsePassportJWTV11(exampleRasPassport);
-        long futureDate = new Date().toInstant().toEpochMilli() + 100000;
-        long pastDate = new Date().toInstant().toEpochMilli() - 100000;
+        long futureDate = Instant.now().toEpochMilli() + 100000;
+        long pastDate = Instant.now().toEpochMilli() - 100000;
 
         List<String> expiredPHS = new ArrayList<>();
         List<String> validPHS = new ArrayList<>();

--- a/pic-sure-auth-services/src/test/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/RASPassPortServiceTest.java
+++ b/pic-sure-auth-services/src/test/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/RASPassPortServiceTest.java
@@ -68,7 +68,7 @@ public class RASPassPortServiceTest {
     @Test
     public void testGa4gpPassportStudies_HasCorrectStudies() {
         Optional<Passport> passport = JWTUtil.parsePassportJWTV11(exampleRasPassport);
-        long futureDate = Instant.now().toEpochMilli() + 100000;
+        long futureDate = (Instant.now().toEpochMilli() / 1000) + 100000;
 
         // Update the expiry date of each permission in our test passport. All permissions in the example passport
         // expired in 2022.
@@ -94,8 +94,8 @@ public class RASPassPortServiceTest {
     @Test
     public void testGa4gpPassportStudies_HalfAreExpired() {
         Optional<Passport> passport = JWTUtil.parsePassportJWTV11(exampleRasPassport);
-        long futureDate = Instant.now().toEpochMilli() + 100000;
-        long pastDate = Instant.now().toEpochMilli() - 100000;
+        long futureDate = (Instant.now().toEpochMilli() / 1000) + 100000;
+        long pastDate = (Instant.now().toEpochMilli() / 1000) - 100000;
 
         List<String> expiredPHS = new ArrayList<>();
         List<String> validPHS = new ArrayList<>();


### PR DESCRIPTION
Updated logic to exclude expired permissions when processing Ga4gh Passports and their corresponding RasDbgapPermissions. Adjusted tests to validate the new filtering behavior, ensuring only non-expired permissions are included.