### PR TITLE
[ALS-8474] Add logging configuration to application properties files

### DIFF
--- a/pic-sure-auth-services/src/main/resources/application.properties
+++ b/pic-sure-auth-services/src/main/resources/application.properties
@@ -28,6 +28,9 @@ logging.level.edu.harvard.hms.dbmi.avillach.auth.service.impl.authentication.FEN
 logging.level.edu.harvard.hms.dbmi.avillach.auth.service.impl.AccessRuleService=${LOGGING_LEVEL_ACCESS_RULE_SERVICE:INFO}
 logging.level.org.springframework.cache=${LOGGING_LEVEL_CACHE:INFO}
 
+# Logging File Output https://docs.spring.io/spring-boot/reference/features/logging.html#features.logging.file-output
+logging.file.name=/var/log/psama.log
+
 # Cache Controller Configuration. This is used to gain insight into the cache.
 # This should never be enabled in production.
 app.cache.inspect.enabled=${CACHE_INSPECT_ENABLED:false}

--- a/pic-sure-auth-services/src/main/resources/application.properties
+++ b/pic-sure-auth-services/src/main/resources/application.properties
@@ -29,6 +29,7 @@ logging.level.edu.harvard.hms.dbmi.avillach.auth.service.impl.AccessRuleService=
 logging.level.org.springframework.cache=${LOGGING_LEVEL_CACHE:INFO}
 
 # Logging File Output https://docs.spring.io/spring-boot/reference/features/logging.html#features.logging.file-output
+# If you are adding additional log files please add them to /var/log/ directory.
 logging.file.name=/var/log/psama.log
 
 # Cache Controller Configuration. This is used to gain insight into the cache.


### PR DESCRIPTION
Added logging.file.name property to specify log file output locations in all relevant property files. This ensures logs are stored in the /var/log/ directory.