### PR TITLE
Add logging file output configuration to application.properties

### DIFF
--- a/pic-sure-auth-services/src/main/resources/application.properties
+++ b/pic-sure-auth-services/src/main/resources/application.properties
@@ -28,6 +28,10 @@ logging.level.edu.harvard.hms.dbmi.avillach.auth.service.impl.authentication.FEN
 logging.level.edu.harvard.hms.dbmi.avillach.auth.service.impl.AccessRuleService=${LOGGING_LEVEL_ACCESS_RULE_SERVICE:INFO}
 logging.level.org.springframework.cache=${LOGGING_LEVEL_CACHE:INFO}
 
+# Logging File Output https://docs.spring.io/spring-boot/reference/features/logging.html#features.logging.file-output
+# If you are adding additional log files please add them to /var/log/ directory.
+logging.file.name=/var/log/psama.log
+
 # Cache Controller Configuration. This is used to gain insight into the cache.
 # This should never be enabled in production.
 app.cache.inspect.enabled=${CACHE_INSPECT_ENABLED:false}


### PR DESCRIPTION
Configure logging to output to a specific file (/var/log/psama.log) following Spring Boot's guidelines. Additional logging files should also be placed in the /var/log/ directory as noted in the comments. This change ensures better logging management and adherence to standard practices.