### PR TITLE
Update env file path for psama Docker container

### DIFF
--- a/jenkinsfile
+++ b/jenkinsfile
@@ -35,7 +35,7 @@ pipeline {
                         sh "docker rm psama || true"
                         sh """docker run --name=psama --restart always \
                             --network=picsure \
-                            --env-file /usr/local/docker-config/psama/.env \
+                            --env-file /usr/local/docker-config/psama/psama.env \
                             $EMAIL_TEMPLATE_VOLUME \
                             $TRUSTSTORE_VOLUME \
                             -e JAVA_OPTS="$PSAMA_OPTS $TRUSTSTORE_JAVA_OPTS" \


### PR DESCRIPTION
Replaced the .env file path with psama.env in the Jenkinsfile to ensure the correct environment configuration is used. This change aligns with updated deployment requirements.