### PR TITLE
[ALS-9219] Clean up roles on startup

### DIFF
--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/repository/RoleRepository.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/repository/RoleRepository.java
@@ -21,4 +21,6 @@ public interface RoleRepository extends JpaRepository<Role, UUID> {
     Set<Role> findByUuidIn(Set<UUID> uuids);
 
     Set<Role> findByNameIn(Set<String> names);
+
+    Set<Role> findByNameNotIn(Set<String> names);
 }

--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/repository/UserRepository.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/repository/UserRepository.java
@@ -4,8 +4,12 @@ import edu.harvard.hms.dbmi.avillach.auth.entity.Connection;
 import edu.harvard.hms.dbmi.avillach.auth.entity.User;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.PagingAndSortingRepository;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Optional;
@@ -38,5 +42,10 @@ public interface UserRepository extends JpaRepository<User, UUID> {
     Optional<User> findByEmailAndConnectionId(String email, String id);
 
     Set<User> findByPassportIsNotNull();
+
+    @Modifying
+    @Query(value = "DELETE FROM user_role where role_id in (:roleIDs)", nativeQuery = true)
+    @Transactional
+    void deleteUserRoles(@Param("roleIDs") List<UUID> roleIDs);
 
 }

--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/AccessRuleService.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/AccessRuleService.java
@@ -383,8 +383,8 @@ public class AccessRuleService {
                 return true;
             }
 
-            if(accessRuleType == AccessRule.TypeNaming.ALL_CONTAINS_OR_EMPTY ||
-            accessRuleType == AccessRule.TypeNaming.ALL_CONTAINS_OR_EMPTY_IGNORE_CASE) {
+            if (accessRuleType == AccessRule.TypeNaming.ALL_CONTAINS_OR_EMPTY ||
+                accessRuleType == AccessRule.TypeNaming.ALL_CONTAINS_OR_EMPTY_IGNORE_CASE) {
                 logger.debug("extractAndCheckRule() -> JsonPath.parse().read() PathNotFound;  passing rule {} for type {}", rule, accessRuleType);
                 return true;
             }
@@ -564,14 +564,20 @@ public class AccessRuleService {
 
         return switch (accessRule.getType()) {
             case AccessRule.TypeNaming.NOT_CONTAINS -> !requestBodyValue.contains(value);
-            case AccessRule.TypeNaming.NOT_CONTAINS_IGNORE_CASE -> !requestBodyValue.toLowerCase().contains(value.toLowerCase());
+            case AccessRule.TypeNaming.NOT_CONTAINS_IGNORE_CASE ->
+                    !requestBodyValue.toLowerCase().contains(value.toLowerCase());
             case (AccessRule.TypeNaming.NOT_EQUALS) -> !value.equals(requestBodyValue);
-            case (AccessRule.TypeNaming.ANY_EQUALS), (AccessRule.TypeNaming.ALL_EQUALS) -> value.equals(requestBodyValue);
-            case (AccessRule.TypeNaming.ALL_CONTAINS), (AccessRule.TypeNaming.ANY_CONTAINS), (AccessRule.TypeNaming.ALL_CONTAINS_OR_EMPTY) -> requestBodyValue.contains(value);
-            case (AccessRule.TypeNaming.ALL_CONTAINS_IGNORE_CASE), (AccessRule.TypeNaming.ALL_CONTAINS_OR_EMPTY_IGNORE_CASE) -> requestBodyValue.toLowerCase().contains(value.toLowerCase());
+            case (AccessRule.TypeNaming.ANY_EQUALS), (AccessRule.TypeNaming.ALL_EQUALS) ->
+                    value.equals(requestBodyValue);
+            case (AccessRule.TypeNaming.ALL_CONTAINS), (AccessRule.TypeNaming.ANY_CONTAINS),
+                 (AccessRule.TypeNaming.ALL_CONTAINS_OR_EMPTY) -> requestBodyValue.contains(value);
+            case (AccessRule.TypeNaming.ALL_CONTAINS_IGNORE_CASE),
+                 (AccessRule.TypeNaming.ALL_CONTAINS_OR_EMPTY_IGNORE_CASE) ->
+                    requestBodyValue.toLowerCase().contains(value.toLowerCase());
             case (AccessRule.TypeNaming.NOT_EQUALS_IGNORE_CASE) -> !value.equalsIgnoreCase(requestBodyValue);
             case (AccessRule.TypeNaming.ALL_EQUALS_IGNORE_CASE) -> value.equalsIgnoreCase(requestBodyValue);
-            case (AccessRule.TypeNaming.ALL_REG_MATCH), (AccessRule.TypeNaming.ANY_REG_MATCH) -> requestBodyValue.matches(value);
+            case (AccessRule.TypeNaming.ALL_REG_MATCH), (AccessRule.TypeNaming.ANY_REG_MATCH) ->
+                    requestBodyValue.matches(value);
             default -> {
                 logger.warn("evaluateAccessRule() incoming accessRule type is out of scope. Just return true.");
                 yield true;
@@ -589,12 +595,8 @@ public class AccessRuleService {
      * @param projectAlias    The project alias.
      */
     protected void configureAccessRule(AccessRule ar, String studyIdentifier, String consent_group, String conceptPath, String projectAlias) {
-        ar.setGates(new HashSet<>());
-        ar.getGates().addAll(getGates(true, false, false));
+        ar.setGates(new HashSet<>(getGates(true, false, false)));
 
-        if (ar.getSubAccessRule() == null) {
-            ar.setSubAccessRule(new HashSet<>());
-        }
         addUniqueSubRules(ar, getAllowedQueryTypeRules());
         addUniqueSubRules(ar, getPhenotypeSubRules(studyIdentifier, conceptPath, projectAlias));
         addUniqueSubRules(ar, getTopmedRestrictedSubRules());
@@ -610,12 +612,7 @@ public class AccessRuleService {
      * @param projectAlias    The project alias.
      */
     protected void configureHarmonizedAccessRule(AccessRule ar, String studyIdentifier, String conceptPath, String projectAlias) {
-        ar.setGates(new HashSet<>());
-        ar.getGates().add(upsertConsentGate("HARMONIZED_CONSENT", "$.query.query.categoryFilters." + fence_harmonized_consent_group_concept_path + "[*]", true, "harmonized data"));
-
-        if (ar.getSubAccessRule() == null) {
-            ar.setSubAccessRule(new HashSet<>());
-        }
+        ar.setGates(new HashSet<>(Collections.singleton(upsertConsentGate("HARMONIZED_CONSENT", "$.query.query.categoryFilters." + fence_harmonized_consent_group_concept_path + "[*]", true, "harmonized data"))));
 
         addUniqueSubRules(ar, getAllowedQueryTypeRules());
         addUniqueSubRules(ar, getHarmonizedSubRules());
@@ -623,12 +620,7 @@ public class AccessRuleService {
     }
 
     protected AccessRule configureClinicalAccessRuleWithPhenoSubRule(AccessRule ar, String studyIdentifier, String consent_group, String conceptPath, String projectAlias) {
-        ar.setGates(new HashSet<>());
-        ar.getGates().addAll(getGates(true, false, true));
-
-        if (ar.getSubAccessRule() == null) {
-            ar.setSubAccessRule(new HashSet<>());
-        }
+        ar.setGates(new HashSet<>(getGates(true, false, true)));
 
         addUniqueSubRules(ar, getAllowedQueryTypeRules());
         addUniqueSubRules(ar, getPhenotypeSubRules(studyIdentifier, conceptPath, projectAlias));
@@ -705,7 +697,7 @@ public class AccessRuleService {
         AccessRule ar = this.getAccessRuleByName(ar_name);
         if (ar != null) {
             // Log and return the existing rule
-            logger.debug("Found existing rule: {}", ar.getName());
+            logger.trace("Found existing rule: {}", ar.getName());
             return ar;
         }
 
@@ -823,12 +815,7 @@ public class AccessRuleService {
     }
 
     protected AccessRule populateTopmedAccessRule(AccessRule rule, boolean includeParent) {
-        if (rule.getGates() == null) {
-            rule.setGates(new HashSet<>(getGates(includeParent, false, true)));
-        } else {
-            rule.getGates().addAll(getGates(includeParent, false, true));
-        }
-
+        rule.setGates(new HashSet<>(getGates(includeParent, false, true)));
         addUniqueSubRules(rule, getAllowedQueryTypeRules());
 
         return rule;
@@ -955,7 +942,7 @@ public class AccessRuleService {
      */
     protected AccessRule upsertHarmonizedAccessRule(String project_name, String consent_group) {
         String ar_name = "AR_TOPMED_" + project_name + "_" + consent_group + "_" + "HARMONIZED";
-        logger.debug("upsertHarmonizedAccessRule() Creating new access rule {}", ar_name);
+        logger.trace("upsertHarmonizedAccessRule() Creating new access rule {}", ar_name);
         String description = "MANAGED AR for " + project_name + "." + consent_group + " Topmed data";
         String ruleText = "$.query.query.categoryFilters." + fence_harmonized_consent_group_concept_path + "[*]";
         String arValue = project_name + "." + consent_group;
@@ -1004,7 +991,7 @@ public class AccessRuleService {
 
     protected AccessRule createPhenotypeSubRule(String conceptPath, String alias, String rule, int ruleType, String label, boolean useMapKey) {
         String ar_name = "AR_PHENO_" + alias + "_" + label;
-        logger.debug("createPhenotypeSubRule() Creating new access rule {}", ar_name);
+        logger.trace("createPhenotypeSubRule() Creating new access rule {}", ar_name);
 
         // Check if the conceptPath has `\\\\` present. This technically represents `\\`.
         if (conceptPath != null && conceptPath.contains("\\\\")) {
@@ -1029,8 +1016,9 @@ public class AccessRuleService {
         return accessRuleCache.computeIfAbsent(name, key -> {
             AccessRule ar = this.getAccessRuleByName(key);
             if (ar == null) {
-                logger.debug("Creating new access rule {}", key);
+                logger.trace("Creating new access rule {}", key);
                 ar = new AccessRule();
+
                 ar.setName(name);
                 ar.setDescription(description);
                 ar.setRule(rule);
@@ -1062,7 +1050,7 @@ public class AccessRuleService {
      * Adds unique sub-rules to the provided parent access rule. This method ensures that duplicate sub-rules,
      * based on their names, are not added to the parent access rule.
      *
-     * @param accessRule the parent access rule to which the sub-rules are added
+     * @param accessRule    the parent access rule to which the sub-rules are added
      * @param subRulesToAdd the collection of sub-rules to be added to the parent access rule
      */
     private void addUniqueSubRules(AccessRule accessRule, Collection<? extends AccessRule> subRulesToAdd) {

--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/PrivilegeService.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/PrivilegeService.java
@@ -122,7 +122,7 @@ public class PrivilegeService {
 
     public Set<Privilege> addPrivileges(Role r, Map<String, StudyMetaData> fenceMapping) {
         String roleName = r.getName();
-        logger.info("addFENCEPrivileges() starting, adding privilege(s) to role {}", roleName);
+        logger.debug("addPrivilege() starting, adding privilege(s) to role {}", roleName);
 
         //each project can have up to three privileges: Parent  |  Harmonized  | Topmed
         //harmonized has 2 ARs for parent + harmonized and harmonized only
@@ -135,13 +135,13 @@ public class PrivilegeService {
         //e.g. MANAGED_phs0000xx_c2 or MANAGED_tutorial-biolinc_camp
         String project_name = extractProject(roleName);
         if (project_name.isEmpty()) {
-            logger.warn("addFENCEPrivileges() role name: {} returned an empty project name", roleName);
+            logger.warn("addPrivileges() role name: {} returned an empty project name", roleName);
         }
         String consent_group = extractConsentGroup(roleName);
         if (!consent_group.isEmpty()) {
-            logger.warn("addFENCEPrivileges() role name: {} returned an empty consent group", roleName);
+            logger.warn("addPrivileges() role name: {} returned an empty consent group", roleName);
         }
-        logger.info("addFENCEPrivileges() project name: {} consent group: {}", project_name, consent_group);
+        logger.debug("addPrivileges() project name: {} consent group: {}", project_name, consent_group);
 
         // Look up the metadata by consent group.
         StudyMetaData projectMetadata = getStudyMappingForProjectAndConsent(project_name, consent_group, fenceMapping);
@@ -170,7 +170,7 @@ public class PrivilegeService {
 
         if (dataType != null && dataType.contains("P")) {
             //insert clinical privs
-            logger.info("addPrivileges() project:{} consent_group:{} concept_path:{}", project_name, consent_group, concept_path);
+            logger.debug("addPrivileges() project:{} consent_group:{} concept_path:{}", project_name, consent_group, concept_path);
             privs.add(upsertClinicalPrivilege(project_name, projectAlias, consent_group, concept_path, false));
 
             //if harmonized study, also create harmonized privileges
@@ -231,7 +231,6 @@ public class PrivilegeService {
             }
             accessRules.addAll(this.accessRuleService.addStandardAccessRules());
             priv.setAccessRules(accessRules);
-            logger.info("Added {} access_rules to privilege", accessRules.size());
 
             priv = this.save(priv);
             logger.info("Added new privilege {} to DB", priv.getName());
@@ -251,18 +250,21 @@ public class PrivilegeService {
 
     private AccessRule createClinicalHarmonizedAccessRule(String studyIdentifier, String consentGroup, String conceptPath, String projectAlias) {
         AccessRule ar = this.accessRuleService.createConsentAccessRule(studyIdentifier, consentGroup, "HARMONIZED", fence_harmonized_consent_group_concept_path);
+        ar.setSubAccessRule(new HashSet<>());
         this.accessRuleService.configureHarmonizedAccessRule(ar, studyIdentifier, conceptPath, projectAlias);
         return this.accessRuleService.save(ar);
     }
 
     private AccessRule createClinicalTopmedParentAccessRule(String studyIdentifier, String consentGroup, String conceptPath, String projectAlias) {
         AccessRule ar = this.accessRuleService.upsertTopmedAccessRule(studyIdentifier, consentGroup, "TOPMED+PARENT");
+        ar.setSubAccessRule(new HashSet<>());
         ar = this.accessRuleService.configureClinicalAccessRuleWithPhenoSubRule(ar, studyIdentifier, consentGroup, conceptPath, projectAlias);
         return this.accessRuleService.save(ar);
     }
 
     private AccessRule createClinicalParentAccessRule(String studyIdentifier, String consentGroup, String conceptPath, String projectAlias) {
         AccessRule ar = this.accessRuleService.createConsentAccessRule(studyIdentifier, consentGroup, "PARENT", fence_parent_consent_group_concept_path);
+        ar.setSubAccessRule(new HashSet<>());
         this.accessRuleService.configureAccessRule(ar, studyIdentifier, consentGroup, conceptPath, projectAlias);
         return this.accessRuleService.save(ar);
     }
@@ -316,6 +318,7 @@ public class PrivilegeService {
 
     private AccessRule createHarmonizedTopmedAccessRule(String studyIdentifier, String projectAlias, String consentGroup, String parentConceptPath) {
         AccessRule harmonizedRule = this.accessRuleService.upsertHarmonizedAccessRule(studyIdentifier, consentGroup);
+        harmonizedRule.setSubAccessRule(new HashSet<>());
         harmonizedRule = this.accessRuleService.populateHarmonizedAccessRule(harmonizedRule, parentConceptPath, studyIdentifier, projectAlias);
         this.accessRuleService.save(harmonizedRule);
         return harmonizedRule;
@@ -323,6 +326,7 @@ public class PrivilegeService {
 
     private AccessRule createTopmedParentAccessRule(String studyIdentifier, String consentGroup, String parentConceptPath, String projectAlias) {
         AccessRule topmedParentRule = this.accessRuleService.upsertTopmedAccessRule(studyIdentifier, consentGroup, "TOPMED+PARENT");
+        topmedParentRule.setSubAccessRule(new HashSet<>());
         this.accessRuleService.populateTopmedAccessRule(topmedParentRule, true);
         topmedParentRule.getSubAccessRule().addAll(this.accessRuleService.getPhenotypeSubRules(studyIdentifier, parentConceptPath, projectAlias));
         topmedParentRule.getSubAccessRule().add(this.accessRuleService.createPhenotypeSubRule(fence_topmed_consent_group_concept_path, "ALLOW_TOPMED_CONSENT", "$.query.query.categoryFilters", AccessRule.TypeNaming.ALL_CONTAINS, "", true));
@@ -412,7 +416,7 @@ public class PrivilegeService {
 
     private StudyMetaData getStudyMappingForProjectAndConsent(String projectId, String consent_group, Map<String, StudyMetaData> fenceMapping) {
         String consentVal = (consent_group != null && !consent_group.isEmpty()) ? projectId + "." + consent_group : projectId;
-        logger.info("getFENCEMappingforProjectAndConsent() looking up {}", consentVal);
+        logger.debug("getStudyMappingForProjectAndConsent() looking up {}", consentVal);
 
         return fenceMapping.get(consentVal);
     }

--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/RoleService.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/RoleService.java
@@ -85,8 +85,8 @@ public class RoleService {
             }
 
             // Then clear privileges from each role and delete them one by one
-            if (!byNameNotIn.isEmpty()) {
-                for (Role role : byNameNotIn) {
+            if (!managedRoles.isEmpty()) {
+                for (Role role : managedRoles) {
                     try {
                         // Clear privileges to remove entries from role_privilege table
                         if (role.getPrivileges() != null && !role.getPrivileges().isEmpty()) {
@@ -102,7 +102,7 @@ public class RoleService {
                         logger.error("Error deleting role {}: {}", role.getName(), e.getMessage(), e);
                     }
                 }
-                logger.info("Deleted {} roles", byNameNotIn.size());
+                logger.info("Deleted {} roles", managedRoles.size());
             }
         } catch (Exception e) {
             logger.error("Error cleaning up roles not in mapping", e);

--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/RoleService.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/RoleService.java
@@ -6,11 +6,13 @@ import edu.harvard.hms.dbmi.avillach.auth.entity.User;
 import edu.harvard.hms.dbmi.avillach.auth.model.fenceMapping.StudyMetaData;
 import edu.harvard.hms.dbmi.avillach.auth.model.ras.RasDbgapPermission;
 import edu.harvard.hms.dbmi.avillach.auth.repository.RoleRepository;
+import edu.harvard.hms.dbmi.avillach.auth.repository.UserRepository;
 import edu.harvard.hms.dbmi.avillach.auth.utils.FenceMappingUtility;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
 import org.springframework.context.event.ContextRefreshedEvent;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Service;
@@ -24,6 +26,7 @@ import java.util.stream.Collectors;
 public class RoleService {
 
     private final Logger logger = LoggerFactory.getLogger(RoleService.class);
+    private final UserRepository userRepository;
     private final RoleRepository roleRepository;
     private final PrivilegeService privilegeService;
     private final FenceMappingUtility fenceMappingUtility;
@@ -31,22 +34,29 @@ public class RoleService {
     public static final String MANAGED_ROLE_NAMED_DATASET = "MANUAL_ROLE_NAMED_DATASET";
     private final Set<Role> publicAccessRoles = new HashSet<>();
 
+    private final ApplicationContext applicationContext;
+
     @Autowired
-    public RoleService(RoleRepository roleRepository, PrivilegeService privilegeService, FenceMappingUtility fenceMappingUtility) {
+    public RoleService(UserRepository userRepository, RoleRepository roleRepository, PrivilegeService privilegeService, FenceMappingUtility fenceMappingUtility, ApplicationContext applicationContext) {
+        this.userRepository = userRepository;
         this.roleRepository = roleRepository;
         this.privilegeService = privilegeService;
         this.fenceMappingUtility = fenceMappingUtility;
+        this.applicationContext = applicationContext;
     }
 
     @EventListener(ContextRefreshedEvent.class)
     public void createPermissionsForFenceMapping() {
         if (this.fenceMappingUtility.getFENCEMapping() != null && this.fenceMappingUtility.getFenceMappingByAuthZ() != null
-                && !this.fenceMappingUtility.getFENCEMapping().isEmpty() && !this.fenceMappingUtility.getFenceMappingByAuthZ().isEmpty()) {
+            && !this.fenceMappingUtility.getFENCEMapping().isEmpty() && !this.fenceMappingUtility.getFenceMappingByAuthZ().isEmpty()) {
             // Create all potential access rules using the fence mapping
             Set<Role> roles = this.fenceMappingUtility.getFenceMappingByAuthZ().values().parallelStream()
                     .filter(this::projectMetaIsValid)
                     .map(this::extractRole)
                     .collect(Collectors.toSet());
+
+            RoleService roleService = applicationContext.getBean(RoleService.class);
+            roleService.cleanupRolesNotInMapping(roles);
 
             this.persistAll(roles);
         } else {
@@ -56,6 +66,33 @@ public class RoleService {
         String publicAccessRolesString = publicAccessRoles.stream().map(Role::getName).collect(Collectors.joining(", "));
         logger.info("Public access roles: {}", publicAccessRolesString);
         logger.info("RoleService initialized...");
+    }
+
+    @Transactional
+    protected void cleanupRolesNotInMapping(Set<Role> roles) {
+        try {
+            // We only want to update MANAGED_ roles
+            Set<String> roleNamesInMapping = roles.stream().map(Role::getName).filter(roleName -> roleName.startsWith("MANAGED_")).collect(Collectors.toSet());
+            Set<Role> byNameNotIn = this.roleRepository.findByNameNotIn(roleNamesInMapping);
+            Set<Role> managedRoles = byNameNotIn.stream().filter(role -> role.getName().startsWith("MANAGED_")).collect(Collectors.toSet());
+            logger.info("List of roles not in the fence mapping: {}", managedRoles.stream().map(Role::getName).collect(Collectors.joining(", ")));
+
+            // First, delete the user-role associations
+            List<UUID> roleIDs = managedRoles.stream().map(Role::getUuid).collect(Collectors.toList());
+            if (!roleIDs.isEmpty()) {
+                this.userRepository.deleteUserRoles(roleIDs);
+                logger.info("Deleted user-role associations for {} roles", roleIDs.size());
+            }
+
+            // Then delete the roles
+            if (!byNameNotIn.isEmpty()) {
+                this.roleRepository.deleteAll(byNameNotIn);
+                logger.info("Deleted {} roles", byNameNotIn.size());
+            }
+        } catch (Exception e) {
+            logger.error("Error cleaning up roles not in mapping", e);
+            throw e;
+        }
     }
 
     private boolean projectMetaIsValid(StudyMetaData projectMetadata) {
@@ -195,7 +232,7 @@ public class RoleService {
         Role role = findByName(roleName);
         if (role != null) {
             // Role already exists
-            logger.debug("upsertRole() role: {} already exists", role.getName());
+            logger.trace("upsertRole() role: {} already exists", role.getName());
         } else {
             logger.info("createRole() New PSAMA role name:{}", roleName);
             // This is a new Role
@@ -291,4 +328,3 @@ public class RoleService {
     }
 
 }
-

--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/UserService.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/UserService.java
@@ -696,7 +696,7 @@ public class UserService {
         Map<String, Role> existingRoles = roleService.findByNames(roleNames);
         List<Role> newRoles = roleNames.stream()
                 .filter(roleName -> !currentRoleNames.contains(roleName))
-                .map(roleName -> existingRoles.getOrDefault(roleName, this.roleService.getOrCreateRole(roleName, "MANAGED role " + roleName)))
+                .map(existingRoles::get)
                 .filter(Objects::nonNull)
                 .collect(Collectors.toList());
 

--- a/pic-sure-auth-services/src/test/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/RoleServiceTest.java
+++ b/pic-sure-auth-services/src/test/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/RoleServiceTest.java
@@ -6,6 +6,7 @@ import edu.harvard.hms.dbmi.avillach.auth.entity.Role;
 import edu.harvard.hms.dbmi.avillach.auth.model.ras.RasDbgapPermission;
 import edu.harvard.hms.dbmi.avillach.auth.repository.PrivilegeRepository;
 import edu.harvard.hms.dbmi.avillach.auth.repository.RoleRepository;
+import edu.harvard.hms.dbmi.avillach.auth.repository.UserRepository;
 import edu.harvard.hms.dbmi.avillach.auth.utils.FenceMappingUtility;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -25,8 +26,11 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 @SpringBootTest
-@ContextConfiguration(classes = {RoleService.class, PrivilegeService.class})
+@ContextConfiguration(classes = {RoleService.class, PrivilegeService.class, UserRepository.class})
 public class RoleServiceTest {
+
+    @MockBean
+    private UserRepository userRepository;
 
     @MockBean
     private ApplicationService applicationService;

--- a/pic-sure-auth-services/src/test/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/authentication/RASAuthenticationServiceTest.java
+++ b/pic-sure-auth-services/src/test/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/authentication/RASAuthenticationServiceTest.java
@@ -10,6 +10,7 @@ import edu.harvard.hms.dbmi.avillach.auth.entity.User;
 import edu.harvard.hms.dbmi.avillach.auth.model.ras.Passport;
 import edu.harvard.hms.dbmi.avillach.auth.model.ras.RasDbgapPermission;
 import edu.harvard.hms.dbmi.avillach.auth.repository.RoleRepository;
+import edu.harvard.hms.dbmi.avillach.auth.repository.UserRepository;
 import edu.harvard.hms.dbmi.avillach.auth.service.impl.*;
 import edu.harvard.hms.dbmi.avillach.auth.utils.FenceMappingUtility;
 import edu.harvard.hms.dbmi.avillach.auth.utils.RestClientUtil;
@@ -18,6 +19,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.MockitoAnnotations;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.ApplicationContext;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.ContextConfiguration;
 
@@ -28,7 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.*;
 
 @SpringBootTest
-@ContextConfiguration(classes = {RASPassPortService.class, RASAuthenticationService.class})
+@ContextConfiguration(classes = {RASPassPortService.class, RASAuthenticationService.class, ApplicationContext.class})
 public class RASAuthenticationServiceTest {
 
     @MockBean
@@ -41,6 +43,10 @@ public class RASAuthenticationServiceTest {
     private CacheEvictionService cacheEvictionService;
     @MockBean
     private RoleService roleService;
+    @MockBean
+    private UserRepository userRepository;
+    @MockBean
+    private ApplicationContext applicationContext;
 
     private RASPassPortService rasPassPortService;
     private RASAuthenticationService rasAuthenticationService;
@@ -54,7 +60,7 @@ public class RASAuthenticationServiceTest {
     @BeforeEach
     public void setUp() throws Exception {
         MockitoAnnotations.openMocks(this);
-        RoleService roleService = new RoleService(mock(RoleRepository.class), mock(PrivilegeService.class), mock(FenceMappingUtility.class));
+        RoleService roleService = new RoleService(mock(UserRepository.class), mock(RoleRepository.class), mock(PrivilegeService.class), mock(FenceMappingUtility.class), mock(ApplicationContext.class));
         this.rasPassPortService = spy(new RASPassPortService(restClientUtil, userService, "", cacheEvictionService));
         doReturn(false).when(rasPassPortService).isExpired(any());
 


### PR DESCRIPTION
If a role doesn't exist in the `fence_mapping.json`, aka the `studies-data.json`, it is removed from users' `user_role` association and the `role` is removed.