### PR TITLE
[ALS-11484] Fix null pointer exception in RASPassPortService and enhance handling of multi-visa scenarios

### DIFF
--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/model/ras/Ga4ghPassportV1.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/model/ras/Ga4ghPassportV1.java
@@ -100,7 +100,7 @@ public class Ga4ghPassportV1 {
         return rasDbgapPermissions;
     }
 
-    public void setRasDbgagPermissions(List<RasDbgapPermission> rasDbgapPermissions) {
+    public void setRasDbgapPermissions(List<RasDbgapPermission> rasDbgapPermissions) {
         this.rasDbgapPermissions = rasDbgapPermissions != null ? rasDbgapPermissions : new ArrayList<>();
     }
 

--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/model/ras/Ga4ghPassportV1.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/model/ras/Ga4ghPassportV1.java
@@ -30,7 +30,7 @@ public class Ga4ghPassportV1 {
     private Ga4ghVisaV1 ga4ghVisaV1;
 
     @JsonProperty("ras_dbgap_permissions")
-    private List<RasDbgapPermission> rasDbgagPermissions = new ArrayList<>();
+    private List<RasDbgapPermission> rasDbgapPermissions = new ArrayList<>();
 
     public String getIss() {
         return iss;
@@ -97,11 +97,11 @@ public class Ga4ghPassportV1 {
     }
 
     public List<RasDbgapPermission> getRasDbgagPermissions() {
-        return rasDbgagPermissions;
+        return rasDbgapPermissions;
     }
 
-    public void setRasDbgagPermissions(List<RasDbgapPermission> rasDbgagPermissions) {
-        this.rasDbgagPermissions = rasDbgagPermissions;
+    public void setRasDbgagPermissions(List<RasDbgapPermission> rasDbgapPermissions) {
+        this.rasDbgapPermissions = rasDbgapPermissions;
     }
 
     @Override
@@ -115,7 +115,7 @@ public class Ga4ghPassportV1 {
                 ", jti='" + jti + '\'' +
                 ", txn='" + txn + '\'' +
                 ", ga4ghVisaV1=" + ga4ghVisaV1 +
-                ", rasDbgagPermissions=" + rasDbgagPermissions +
+                ", rasDbgapPermissions=" + rasDbgapPermissions +
                 '}';
     }
 }

--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/model/ras/Ga4ghPassportV1.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/model/ras/Ga4ghPassportV1.java
@@ -101,7 +101,7 @@ public class Ga4ghPassportV1 {
     }
 
     public void setRasDbgagPermissions(List<RasDbgapPermission> rasDbgapPermissions) {
-        this.rasDbgapPermissions = rasDbgapPermissions;
+        this.rasDbgapPermissions = rasDbgapPermissions != null ? rasDbgapPermissions : new ArrayList<>();
     }
 
     @Override

--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/model/ras/Ga4ghPassportV1.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/model/ras/Ga4ghPassportV1.java
@@ -2,6 +2,7 @@ package edu.harvard.hms.dbmi.avillach.auth.model.ras;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -29,7 +30,7 @@ public class Ga4ghPassportV1 {
     private Ga4ghVisaV1 ga4ghVisaV1;
 
     @JsonProperty("ras_dbgap_permissions")
-    private List<RasDbgapPermission> rasDbgagPermissions;
+    private List<RasDbgapPermission> rasDbgagPermissions = new ArrayList<>();
 
     public String getIss() {
         return iss;

--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/RASPassPortService.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/RASPassPortService.java
@@ -213,7 +213,8 @@ public class RASPassPortService {
         ga4ghPassports.forEach(ga4ghPassport -> {
             if (ga4ghPassport.isPresent()) {
                 Ga4ghPassportV1 ga4ghPassportV1 = ga4ghPassport.get();
-                rasDbgapPermissions.addAll(ga4ghPassportV1.getRasDbgagPermissions().stream().filter(rasDbgapPermission -> date <= rasDbgapPermission.getExpiration()).collect(Collectors.toSet()));
+                List<RasDbgapPermission> permissions = ga4ghPassportV1.getRasDbgagPermissions();
+                rasDbgapPermissions.addAll(permissions.stream().filter(rasDbgapPermission -> date <= rasDbgapPermission.getExpiration()).collect(Collectors.toSet()));
             }
         });
 

--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/RASPassPortService.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/RASPassPortService.java
@@ -202,7 +202,7 @@ public class RASPassPortService {
         return Optional.ofNullable(responseVal);
     }
 
-    public Set<RasDbgapPermission> ga4gpPassportToRasDbgapPermissions(Set<Optional<Ga4ghPassportV1>> ga4ghPassports) {
+    public Set<RasDbgapPermission> ga4ghPassportToRasDbgapPermissions(Set<Optional<Ga4ghPassportV1>> ga4ghPassports) {
         if (ga4ghPassports == null) {
             return null;
         }

--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/authentication/RASAuthenticationService.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/authentication/RASAuthenticationService.java
@@ -150,7 +150,7 @@ public class RASAuthenticationService extends OktaAuthenticationService implemen
     protected User updateRasUserRoles(String code, User user, Passport rasPassport) {
         logger.info("RAS PASSPORT FOUND ___ USER: {} ___ PASSPORT: {} ___ CODE {}", user.getSubject(), rasPassport, code);
         Set<Optional<Ga4ghPassportV1>> ga4ghPassports = rasPassport.getGa4ghPassportV1().stream().map(JWTUtil::parseGa4ghPassportV1).filter(Optional::isPresent).collect(Collectors.toSet());
-        Set<RasDbgapPermission> dbgapPermissions = this.rasPassPortService.ga4gpPassportToRasDbgapPermissions(ga4ghPassports);
+        Set<RasDbgapPermission> dbgapPermissions = this.rasPassPortService.ga4ghPassportToRasDbgapPermissions(ga4ghPassports);
         Set<String> dbgapRoleNames = this.roleService.getRoleNamesForDbgapPermissions(dbgapPermissions);
         user = userService.updateUserRoles(user, dbgapRoleNames);
 

--- a/pic-sure-auth-services/src/test/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/RASPassPortServiceTest.java
+++ b/pic-sure-auth-services/src/test/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/RASPassPortServiceTest.java
@@ -92,7 +92,7 @@ public class RASPassPortServiceTest {
                     Ga4ghPassportV1 ga4ghPassportV1 = optionalPassport.get();
                     List<RasDbgapPermission> rasDbgapPermissions = ga4ghPassportV1.getRasDbgagPermissions();
                     List<RasDbgapPermission> newExpires = rasDbgapPermissions.stream().peek(rasDbgapPermission -> rasDbgapPermission.setExpiration(futureDate)).toList();
-                    ga4ghPassportV1.setRasDbgagPermissions(newExpires);
+                    ga4ghPassportV1.setRasDbgapPermissions(newExpires);
                     return Optional.of(ga4ghPassportV1);
                 })
                 .collect(Collectors.toSet());
@@ -136,7 +136,7 @@ public class RASPassPortServiceTest {
                             })
                             .collect(Collectors.toList());
 
-                    ga4ghPassportV1.setRasDbgagPermissions(updatedPermissions);
+                    ga4ghPassportV1.setRasDbgapPermissions(updatedPermissions);
                     return Optional.of(ga4ghPassportV1);
                 })
                 .collect(Collectors.toSet());
@@ -281,7 +281,7 @@ public class RASPassPortServiceTest {
                     List<RasDbgapPermission> newExpires = rasDbgapPermissions.stream()
                             .peek(rasDbgapPermission -> rasDbgapPermission.setExpiration(futureDate))
                             .toList();
-                    ga4ghPassportV1.setRasDbgagPermissions(newExpires);
+                    ga4ghPassportV1.setRasDbgapPermissions(newExpires);
                     return Optional.of(ga4ghPassportV1);
                 })
                 .collect(Collectors.toSet());

--- a/pic-sure-auth-services/src/test/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/RASPassPortServiceTest.java
+++ b/pic-sure-auth-services/src/test/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/RASPassPortServiceTest.java
@@ -90,8 +90,8 @@ public class RASPassPortServiceTest {
                 .filter(Optional::isPresent)
                 .map(optionalPassport -> {
                     Ga4ghPassportV1 ga4ghPassportV1 = optionalPassport.get();
-                    List<RasDbgapPermission> rasDbgagPermissions = ga4ghPassportV1.getRasDbgagPermissions();
-                    List<RasDbgapPermission> newExpires = rasDbgagPermissions.stream().peek(rasDbgapPermission -> rasDbgapPermission.setExpiration(futureDate)).toList();
+                    List<RasDbgapPermission> rasDbgapPermissions = ga4ghPassportV1.getRasDbgagPermissions();
+                    List<RasDbgapPermission> newExpires = rasDbgapPermissions.stream().peek(rasDbgapPermission -> rasDbgapPermission.setExpiration(futureDate)).toList();
                     ga4ghPassportV1.setRasDbgagPermissions(newExpires);
                     return Optional.of(ga4ghPassportV1);
                 })
@@ -119,10 +119,10 @@ public class RASPassPortServiceTest {
                 .filter(Optional::isPresent)
                 .map(optionalPassport -> {
                     Ga4ghPassportV1 ga4ghPassportV1 = optionalPassport.get();
-                    List<RasDbgapPermission> rasDbgagPermissions = ga4ghPassportV1.getRasDbgagPermissions();
+                    List<RasDbgapPermission> rasDbgapPermissions = ga4ghPassportV1.getRasDbgagPermissions();
 
                     AtomicInteger index = new AtomicInteger();
-                    List<RasDbgapPermission> updatedPermissions = rasDbgagPermissions.stream()
+                    List<RasDbgapPermission> updatedPermissions = rasDbgapPermissions.stream()
                             .peek(permission -> {
                                 if (index.getAndIncrement() % 2 == 0) {
                                     // For even indices, use a valid future expiration.
@@ -277,8 +277,8 @@ public class RASPassPortServiceTest {
                 .filter(Optional::isPresent)
                 .map(optionalPassport -> {
                     Ga4ghPassportV1 ga4ghPassportV1 = optionalPassport.get();
-                    List<RasDbgapPermission> rasDbgagPermissions = ga4ghPassportV1.getRasDbgagPermissions();
-                    List<RasDbgapPermission> newExpires = rasDbgagPermissions.stream()
+                    List<RasDbgapPermission> rasDbgapPermissions = ga4ghPassportV1.getRasDbgagPermissions();
+                    List<RasDbgapPermission> newExpires = rasDbgapPermissions.stream()
                             .peek(rasDbgapPermission -> rasDbgapPermission.setExpiration(futureDate))
                             .toList();
                     ga4ghPassportV1.setRasDbgagPermissions(newExpires);

--- a/pic-sure-auth-services/src/test/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/RASPassPortServiceTest.java
+++ b/pic-sure-auth-services/src/test/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/RASPassPortServiceTest.java
@@ -53,6 +53,16 @@ public class RASPassPortServiceTest {
 
     private static final String exampleRasPassport = "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6ImRlZmF1bHRfc3NsX2tleSJ9.ew0KInN1YiI6IjJLRWthUC1SeDJGdkJCOExRVjRucjVmZXlySG4yNXEwV3hVd1kxVDIwMnMiLA0KImp0aSI6ImNiZDFjMzkyLTk0YjYtNDc2Yi1iYjA5LTk2MWY4MTM3MmE2NCIsDQoic2NvcGUiOiJvcGVuaWQgZ2E0Z2hfcGFzc3BvcnRfdjEiLA0KInR4biI6IlRsdVJ1UVcvZlZrPS5mYWJkOTdkMTdkNGM4OGFiIiwNCiJpc3MiOiAiaHR0cHM6Ly9zdHNzdGcubmloLmdvdiIsIAoiaWF0IjogMTYyMDIxMDM2MiwKImV4cCI6IDE2MjAyNTM1NjIsCiJnYTRnaF9wYXNzcG9ydF92MSIgOiBbImV3MEtJQ0FpZEhsd0lqb2dJa3BYVkNJc0RRb2dJQ0poYkdjaU9pQWlVbE15TlRZaUxBMEtJQ0FpYTJsa0lqb2dJbVJsWm1GMWJIUmZjM05zWDJ0bGVTSU5DbjAuZXcwS0lDQWlhWE56SWpvZ0ltaDBkSEJ6T2k4dmMzUnpjM1JuTG01cGFDNW5iM1lpTEEwS0lDQWljM1ZpSWpvZ0lqSkxSV3RoVUMxU2VESkdka0pDT0V4UlZqUnVjalZtWlhseVNHNHlOWEV3VjNoVmQxa3hWREl3TW5NaUxDQU5DaUFnSW1saGRDSTZJREUyTWpBeU1UQXpOaklzRFFvZ0lDSmxlSEFpT2lBeE5qSXdNalV6TlRZeUxBMEtJQ0FpYzJOdmNHVWlPaUFpYjNCbGJtbGtJR2RoTkdkb1gzQmhjM053YjNKMFgzWXhJaXdOQ2lBZ0ltcDBhU0k2SUNJNU56UTNPV0UzTXkwMFltSmxMVFJoWVdVdE9HWTFNUzAxTldVNU9UQTBZalJqT1RnaUxBMEtJQ0FpZEhodUlqb2dJbFJzZFZKMVVWY3ZabFpyUFM1bVlXSmtPVGRrTVRka05HTTRPR0ZpSWl3TkNpQWdJbWRoTkdkb1gzWnBjMkZmZGpFaU9pQjdJQTBLSUNBZ0lDQWlkSGx3WlNJNklDSm9kSFJ3Y3pvdkwzSmhjeTV1YVdndVoyOTJMM1pwYzJGekwzWXhMakVpTENBTkNpQWdJQ0FnSW1GemMyVnlkR1ZrSWpvZ01UWXlNREl4TURNMk1pd05DaUFnSUNBZ0luWmhiSFZsSWpvZ0ltaDBkSEJ6T2k4dmMzUnpjM1JuTG01cGFDNW5iM1l2Y0dGemMzQnZjblF2WkdKbllYQXZkakV1TVNJc0RRb2dJQ0FnSUNKemIzVnlZMlVpT2lBaWFIUjBjSE02THk5dVkySnBMbTVzYlM1dWFXZ3VaMjkyTDJkaGNDSXNEUW9nSUNBZ0lDSmllU0k2SUNKa1lXTWlmU3dOQ2lBZ0lDQWdJbkpoYzE5a1ltZGhjRjl3WlhKdGFYTnphVzl1Y3lJNklGc05DaUFnSUNBZ0lDQWdJQTBLZXcwS0ltTnZibk5sYm5SZmJtRnRaU0k2SWtkbGJtVnlZV3dnVW1WelpXRnlZMmdnVlhObElpd0pEUW9pY0doelgybGtJam9pY0doek1EQXdNREEySWl3TkNpSjJaWEp6YVc5dUlqb2lkakVpTEEwS0luQmhjblJwWTJsd1lXNTBYM05sZENJNkluQXhJaXdKQ1EwS0ltTnZibk5sYm5SZlozSnZkWEFpT2lKak1TSXNEUW9pY205c1pTSTZJbkJwSWl3TkNpSmxlSEJwY21GMGFXOXVJam94TmpReE1ERXpNakF3RFFwOUxBMEtldzBLSW1OdmJuTmxiblJmYm1GdFpTSTZJa1Y0WTJoaGJtZGxJRUZ5WldFaUxBa05DaUp3YUhOZmFXUWlPaUp3YUhNd01EQXpNREFpTEEwS0luWmxjbk5wYjI0aU9pSjJNU0lzRFFvaWNHRnlkR2xqYVhCaGJuUmZjMlYwSWpvaWNERWlMQWtKRFFvaVkyOXVjMlZ1ZEY5bmNtOTFjQ0k2SW1NNU9Ua2lMQTBLSW5KdmJHVWlPaUp3YVNJc0RRb2laWGh3YVhKaGRHbHZiaUk2TVRZME1UQXhNekl3TUFrTkNuME5DaUFnSUNBZ1hTQU5DbjAuTnpSOEtzZTJOOUtFOXhvLUo4dXdUaWxzUG9pYXhNWGlGR0prY0JOYTMtOGt1ZEh3MFd6U0xDM3Z3Qk4yZ3Z0RUtMZ2ZBeVpVUDZrc0ktRzlOV0NIU3Z2RG4tbFNhbjVtV1dfWEhrRVdGWGd3RXotWlNNalBvV0Vndlk1bHhSWEhxR1lhWmQ5U2puTjdsTFpUbHNQLU9pbFUxcUNyQ205YzVfcTh1YWJyZ3o0OW5PWFRGZEpKblpPT1ZzUmtkU0NjVnlHczRlbUxNSjdDdVd2ckU2RkR2Ri1QTUpGNlhHYnN3R1pjVFRPM3h0MjR6Tk1wbm5RUEVzNXQ3Tk1LZjhucEJ3czNvd0FKcklTRkExYTNmUWtJZU83dFRUUGVSX1FRVUlxYzFJRW5JdlotMGdsNE5ETEZRSjJTTS1KdUtvSWdnQWt3NVNGWDNhSk9WNC12b2JZbXhBIl0NCn0.sJwAZeR8cYyF-BCluC9fmiQAi14L7hC3DB4MoFQNNdoakUBujPZ-NlpfP2rBgJQ3CGcxsF95Vdczm6Yk4TKa68eXkKjkswjsSSQg0qErgFhN2jis9KMxnMfmfPNUfb0lioHtD-_oghRkd9239oUwLR06KB5Ux3mD4Pc0ZPbJxJcPmyP9DZ8WEHmAFIJpcoayHwJDr1jt-GbqUtaTCs1VQ9Habh8Z8fvwrlvQNj744m5eq6141bD0G15KgvbyYf9L4_PYNgMjTyUx9EGyetrxQ4XmOpDF_ZbFEhZliy80qfO2HGQzSId-dKXCvPI_SUWcCVeJqPwmXTirTt9qJ63ypw";
 
+    // Passport with two visas: LinkedIdentities (no ras_dbgap_permissions) + RAS dbGaP (with 2 permissions)
+    private static final String multiVisaPassportWithPermissions = "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6InRlc3Qta2V5In0"
+            + ".eyJzdWIiOiJ0ZXN0LXN1Yi0wMDEiLCJqdGkiOiJwYXNzcG9ydC1qdGktMDAxIiwic2NvcGUiOiJvcGVuaWQgZ2E0Z2hfcGFzc3BvcnRfdjEiLCJ0eG4iOiJ0ZXN0LXR4bi0wMDEiLCJpc3MiOiJodHRwczovL3N0c3N0Zy5uaWguZ292IiwiaWF0IjoxNjIwMjEwMzYyLCJleHAiOjE2MjAyNTM1NjIsImdhNGdoX3Bhc3Nwb3J0X3YxIjpbImV5SjBlWEFpT2lKS1YxUWlMQ0poYkdjaU9pSlNVekkxTmlJc0ltdHBaQ0k2SW5SbGMzUXRhMlY1SW4wLmV5SnBjM01pT2lKb2RIUndjem92TDNOMGMzTjBaeTV1YVdndVoyOTJJaXdpYzNWaUlqb2lkR1Z6ZEMxemRXSXRNREF4SWl3aWFXRjBJam94TmpJd01qRXdNell5TENKbGVIQWlPakUyTWpBeU5UTTFOaklzSW5OamIzQmxJam9pYjNCbGJtbGtJR2RoTkdkb1gzQmhjM053YjNKMFgzWXhJaXdpYW5ScElqb2lkbWx6WVMxcWRHa3RiR2x1YTJWa0xUQXdNU0lzSW5SNGJpSTZJblJsYzNRdGRIaHVMVEF3TVNJc0ltZGhOR2RvWDNacGMyRmZkakVpT25zaWRIbHdaU0k2SWt4cGJtdGxaRWxrWlc1MGFYUnBaWE1pTENKaGMzTmxjblJsWkNJNk1UWXlNREl4TURNMk1pd2lkbUZzZFdVaU9pSjBaWE4wTFd4cGJtdGxaQzFwWkMxMllXeDFaU0lzSW5OdmRYSmpaU0k2SW1oMGRIQnpPaTh2YzNSemMzUm5MbTVwYUM1bmIzWWlMQ0ppZVNJNkltNXBhQzVuYjNZaWZYMC5mYWtlc2lnbmF0dXJlIiwiZXlKMGVYQWlPaUpLVjFRaUxDSmhiR2NpT2lKU1V6STFOaUlzSW10cFpDSTZJblJsYzNRdGEyVjVJbjAuZXlKcGMzTWlPaUpvZEhSd2N6b3ZMM04wYzNOMFp5NXVhV2d1WjI5Mklpd2ljM1ZpSWpvaWRHVnpkQzF6ZFdJdE1EQXhJaXdpYVdGMElqb3hOakl3TWpFd016WXlMQ0psZUhBaU9qRTJNakF5TlRNMU5qSXNJbk5qYjNCbElqb2liM0JsYm1sa0lHZGhOR2RvWDNCaGMzTndiM0owWDNZeElpd2lhblJwSWpvaWRtbHpZUzFxZEdrdFpHSm5ZWEF0TURBeElpd2lkSGh1SWpvaWRHVnpkQzEwZUc0dE1EQXhJaXdpWjJFMFoyaGZkbWx6WVY5Mk1TSTZleUowZVhCbElqb2lhSFIwY0hNNkx5OXlZWE11Ym1sb0xtZHZkaTkyYVhOaGN5OTJNUzR4SWl3aVlYTnpaWEowWldRaU9qRTJNakF5TVRBek5qSXNJblpoYkhWbElqb2lhSFIwY0hNNkx5OXpkSE56ZEdjdWJtbG9MbWR2ZGk5d1lYTnpjRzl5ZEM5a1ltZGhjQzkyTVM0eElpd2ljMjkxY21ObElqb2lhSFIwY0hNNkx5OXVZMkpwTG01c2JTNXVhV2d1WjI5MkwyZGhjQ0lzSW1KNUlqb2laR0ZqSW4wc0luSmhjMTlrWW1kaGNGOXdaWEp0YVhOemFXOXVjeUk2VzNzaVkyOXVjMlZ1ZEY5dVlXMWxJam9pUjJWdVpYSmhiQ0JTWlhObFlYSmphQ0JWYzJVaUxDSndhSE5mYVdRaU9pSndhSE13TURBd01EY2lMQ0oyWlhKemFXOXVJam9pZGpNeklpd2ljR0Z5ZEdsamFYQmhiblJmYzJWMElqb2ljREVpTENKamIyNXpaVzUwWDJkeWIzVndJam9pWXpFaUxDSnliMnhsSWpvaWNHa2lMQ0psZUhCcGNtRjBhVzl1SWpveE5qUXhNREV6TWpBd2ZTeDdJbU52Ym5ObGJuUmZibUZ0WlNJNklraGxZV3gwYUNCTlpXUnBZMkZzSUVKcGIyMWxaR2xqWVd3aUxDSndhSE5mYVdRaU9pSndhSE13TURBeE56a2lMQ0oyWlhKemFXOXVJam9pZGpnaUxDSndZWEowYVdOcGNHRnVkRjl6WlhRaU9pSndNaUlzSW1OdmJuTmxiblJmWjNKdmRYQWlPaUpqTWlJc0luSnZiR1VpT2lKd2FTSXNJbVY0Y0dseVlYUnBiMjRpT2pFMk5ERXdNVE15TURCOVhYMC5mYWtlc2lnbmF0dXJlIl19"
+            + ".fakesignature";
+
+    // Passport with two visas: LinkedIdentities (no ras_dbgap_permissions) + RAS dbGaP (empty permissions)
+    private static final String multiVisaPassportWithEmptyPermissions = "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6InRlc3Qta2V5In0"
+            + ".eyJzdWIiOiJ0ZXN0LXN1Yi0wMDEiLCJqdGkiOiJwYXNzcG9ydC1qdGktMDAyIiwic2NvcGUiOiJvcGVuaWQgZ2E0Z2hfcGFzc3BvcnRfdjEiLCJ0eG4iOiJ0ZXN0LXR4bi0wMDEiLCJpc3MiOiJodHRwczovL3N0c3N0Zy5uaWguZ292IiwiaWF0IjoxNjIwMjEwMzYyLCJleHAiOjE2MjAyNTM1NjIsImdhNGdoX3Bhc3Nwb3J0X3YxIjpbImV5SjBlWEFpT2lKS1YxUWlMQ0poYkdjaU9pSlNVekkxTmlJc0ltdHBaQ0k2SW5SbGMzUXRhMlY1SW4wLmV5SnBjM01pT2lKb2RIUndjem92TDNOMGMzTjBaeTV1YVdndVoyOTJJaXdpYzNWaUlqb2lkR1Z6ZEMxemRXSXRNREF4SWl3aWFXRjBJam94TmpJd01qRXdNell5TENKbGVIQWlPakUyTWpBeU5UTTFOaklzSW5OamIzQmxJam9pYjNCbGJtbGtJR2RoTkdkb1gzQmhjM053YjNKMFgzWXhJaXdpYW5ScElqb2lkbWx6WVMxcWRHa3RiR2x1YTJWa0xUQXdNU0lzSW5SNGJpSTZJblJsYzNRdGRIaHVMVEF3TVNJc0ltZGhOR2RvWDNacGMyRmZkakVpT25zaWRIbHdaU0k2SWt4cGJtdGxaRWxrWlc1MGFYUnBaWE1pTENKaGMzTmxjblJsWkNJNk1UWXlNREl4TURNMk1pd2lkbUZzZFdVaU9pSjBaWE4wTFd4cGJtdGxaQzFwWkMxMllXeDFaU0lzSW5OdmRYSmpaU0k2SW1oMGRIQnpPaTh2YzNSemMzUm5MbTVwYUM1bmIzWWlMQ0ppZVNJNkltNXBhQzVuYjNZaWZYMC5mYWtlc2lnbmF0dXJlIiwiZXlKMGVYQWlPaUpLVjFRaUxDSmhiR2NpT2lKU1V6STFOaUlzSW10cFpDSTZJblJsYzNRdGEyVjVJbjAuZXlKcGMzTWlPaUpvZEhSd2N6b3ZMM04wYzNOMFp5NXVhV2d1WjI5Mklpd2ljM1ZpSWpvaWRHVnpkQzF6ZFdJdE1EQXhJaXdpYVdGMElqb3hOakl3TWpFd016WXlMQ0psZUhBaU9qRTJNakF5TlRNMU5qSXNJbk5qYjNCbElqb2liM0JsYm1sa0lHZGhOR2RvWDNCaGMzTndiM0owWDNZeElpd2lhblJwSWpvaWRtbHpZUzFxZEdrdFpHSm5ZWEF0Wlcxd2RIa3RNREF4SWl3aWRIaHVJam9pZEdWemRDMTBlRzR0TURBeElpd2laMkUwWjJoZmRtbHpZVjkyTVNJNmV5SjBlWEJsSWpvaWFIUjBjSE02THk5eVlYTXVibWxvTG1kdmRpOTJhWE5oY3k5Mk1TNHhJaXdpWVhOelpYSjBaV1FpT2pFMk1qQXlNVEF6TmpJc0luWmhiSFZsSWpvaWFIUjBjSE02THk5emRITnpkR2N1Ym1sb0xtZHZkaTl3WVhOemNHOXlkQzlrWW1kaGNDOTJNUzR4SWl3aWMyOTFjbU5sSWpvaWFIUjBjSE02THk5dVkySnBMbTVzYlM1dWFXZ3VaMjkyTDJkaGNDSXNJbUo1SWpvaVpHRmpJbjBzSW5KaGMxOWtZbWRoY0Y5d1pYSnRhWE56YVc5dWN5STZXMTE5LmZha2VzaWduYXR1cmUiXX0"
+            + ".fakesignature";
+
     @Test
     public void testGa4ghPassPortStudies_IsNull() {
         Set<RasDbgapPermission> permissions = rasPassPortService.ga4gpPassportToRasDbgapPermissions(null);
@@ -235,6 +245,53 @@ public class RASPassPortServiceTest {
         Optional<String> response = rasPassPortService.validateVisa(visa);
         assertTrue(response.isPresent());
         assertEquals(PassportValidationResponse.PERMISSION_UPDATE.getValue(), response.get());
+    }
+
+    @Test
+    public void testMultiVisaPassport_LinkedIdentitiesVisaHasNoPermissions_DoesNotThrowNPE() {
+        Optional<Passport> passport = JWTUtil.parsePassportJWTV11(multiVisaPassportWithEmptyPermissions);
+        assertTrue(passport.isPresent());
+        assertEquals(2, passport.get().getGa4ghPassportV1().size());
+
+        Set<Optional<Ga4ghPassportV1>> ga4ghPassports = passport.get().getGa4ghPassportV1().stream()
+                .map(JWTUtil::parseGa4ghPassportV1)
+                .filter(Optional::isPresent)
+                .collect(Collectors.toSet());
+
+        // Should not throw NPE even though LinkedIdentities visa has no ras_dbgap_permissions
+        Set<RasDbgapPermission> permissions = rasPassPortService.ga4gpPassportToRasDbgapPermissions(ga4ghPassports);
+        assertNotNull(permissions);
+        assertTrue(permissions.isEmpty());
+    }
+
+    @Test
+    public void testMultiVisaPassport_WithPermissions_ReturnsCorrectStudies() {
+        Optional<Passport> passport = JWTUtil.parsePassportJWTV11(multiVisaPassportWithPermissions);
+        assertTrue(passport.isPresent());
+        assertEquals(2, passport.get().getGa4ghPassportV1().size());
+
+        long futureDate = (Instant.now().toEpochMilli() / 1000) + 100000;
+
+        Set<Optional<Ga4ghPassportV1>> ga4ghPassports = passport.get().getGa4ghPassportV1().stream()
+                .map(JWTUtil::parseGa4ghPassportV1)
+                .filter(Optional::isPresent)
+                .map(optionalPassport -> {
+                    Ga4ghPassportV1 ga4ghPassportV1 = optionalPassport.get();
+                    List<RasDbgapPermission> rasDbgagPermissions = ga4ghPassportV1.getRasDbgagPermissions();
+                    List<RasDbgapPermission> newExpires = rasDbgagPermissions.stream()
+                            .peek(rasDbgapPermission -> rasDbgapPermission.setExpiration(futureDate))
+                            .toList();
+                    ga4ghPassportV1.setRasDbgagPermissions(newExpires);
+                    return Optional.of(ga4ghPassportV1);
+                })
+                .collect(Collectors.toSet());
+
+        Set<RasDbgapPermission> permissions = rasPassPortService.ga4gpPassportToRasDbgapPermissions(ga4ghPassports);
+
+        // Only the dbGaP visa has permissions - LinkedIdentities visa has none
+        assertEquals(2, permissions.size());
+        assertTrue(permissions.stream().anyMatch(p -> p.getPhsId().equals("phs000007")));
+        assertTrue(permissions.stream().anyMatch(p -> p.getPhsId().equals("phs000179")));
     }
 
 }

--- a/pic-sure-auth-services/src/test/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/RASPassPortServiceTest.java
+++ b/pic-sure-auth-services/src/test/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/RASPassPortServiceTest.java
@@ -65,7 +65,7 @@ public class RASPassPortServiceTest {
 
     @Test
     public void testGa4ghPassPortStudies_IsNull() {
-        Set<RasDbgapPermission> permissions = rasPassPortService.ga4gpPassportToRasDbgapPermissions(null);
+        Set<RasDbgapPermission> permissions = rasPassPortService.ga4ghPassportToRasDbgapPermissions(null);
         assertNull(permissions);
     }
 
@@ -73,7 +73,7 @@ public class RASPassPortServiceTest {
     public void testGa4gpPassportStudies_IsNotNull_And_ExpiredPermissionsExcluded() {
         Optional<Passport> passport = JWTUtil.parsePassportJWTV11(exampleRasPassport);
         Set<Optional<Ga4ghPassportV1>> ga4ghPassports = passport.get().getGa4ghPassportV1().stream().map(JWTUtil::parseGa4ghPassportV1).filter(Optional::isPresent).collect(Collectors.toSet());
-        Set<RasDbgapPermission> permissions = rasPassPortService.ga4gpPassportToRasDbgapPermissions(ga4ghPassports);
+        Set<RasDbgapPermission> permissions = rasPassPortService.ga4ghPassportToRasDbgapPermissions(ga4ghPassports);
         assertNotNull(permissions);
         assertTrue(permissions.isEmpty());
     }
@@ -97,7 +97,7 @@ public class RASPassPortServiceTest {
                 })
                 .collect(Collectors.toSet());
 
-        Set<RasDbgapPermission> permissions = rasPassPortService.ga4gpPassportToRasDbgapPermissions(ga4ghPassports);
+        Set<RasDbgapPermission> permissions = rasPassPortService.ga4ghPassportToRasDbgapPermissions(ga4ghPassports);
 
         assertEquals(2, permissions.size());
         assertTrue(permissions.stream().anyMatch(p -> p.getPhsId().equals("phs000300")));
@@ -143,7 +143,7 @@ public class RASPassPortServiceTest {
 
         // Convert the GA4GH passports to RAS DbGaP permissions. The underlying conversion
         // should filter out the ones with invalid expiration dates.
-        Set<RasDbgapPermission> permissions = rasPassPortService.ga4gpPassportToRasDbgapPermissions(ga4ghPassports);
+        Set<RasDbgapPermission> permissions = rasPassPortService.ga4ghPassportToRasDbgapPermissions(ga4ghPassports);
 
         // We expect only the valid (future-dated) permissions to be returned.
         assertEquals(validPHS.size(), permissions.size());
@@ -259,7 +259,7 @@ public class RASPassPortServiceTest {
                 .collect(Collectors.toSet());
 
         // Should not throw NPE even though LinkedIdentities visa has no ras_dbgap_permissions
-        Set<RasDbgapPermission> permissions = rasPassPortService.ga4gpPassportToRasDbgapPermissions(ga4ghPassports);
+        Set<RasDbgapPermission> permissions = rasPassPortService.ga4ghPassportToRasDbgapPermissions(ga4ghPassports);
         assertNotNull(permissions);
         assertTrue(permissions.isEmpty());
     }
@@ -286,7 +286,7 @@ public class RASPassPortServiceTest {
                 })
                 .collect(Collectors.toSet());
 
-        Set<RasDbgapPermission> permissions = rasPassPortService.ga4gpPassportToRasDbgapPermissions(ga4ghPassports);
+        Set<RasDbgapPermission> permissions = rasPassPortService.ga4ghPassportToRasDbgapPermissions(ga4ghPassports);
 
         // Only the dbGaP visa has permissions - LinkedIdentities visa has none
         assertEquals(2, permissions.size());

--- a/pic-sure-auth-services/src/test/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/authentication/RASAuthenticationServiceTest.java
+++ b/pic-sure-auth-services/src/test/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/authentication/RASAuthenticationServiceTest.java
@@ -147,7 +147,7 @@ public class RASAuthenticationServiceTest {
         Set<RasDbgapPermission> dbgapPermissions = new HashSet<>();
         Set<String> dbgapRoleNames = new HashSet<>();
 
-        when(rasPassPortService.ga4gpPassportToRasDbgapPermissions(any())).thenReturn(dbgapPermissions);
+        when(rasPassPortService.ga4ghPassportToRasDbgapPermissions(any())).thenReturn(dbgapPermissions);
         when(roleService.getRoleNamesForDbgapPermissions(any())).thenReturn(dbgapRoleNames);
         when(userService.updateUserRoles(any(), any())).thenReturn(user);
         when(userService.updateUserConsents(any(), any())).thenReturn(user);


### PR DESCRIPTION
- Fixed NPE in `RASPassPortService` when handling `LinkedIdentities` visa without `ras_dbgap_permissions`.
- Initialized `rasDbgagPermissions` in `Ga4ghPassportV1` to prevent null access.
- Added comprehensive test cases to cover multi-visa scenarios with and without permissions.