### PR TITLE
[ALS-10196] Add roles to UserService responseMap so it will correctly propogate

### DIFF
--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/TokenService.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/TokenService.java
@@ -189,13 +189,10 @@ public class TokenService {
 
         if (isLongTermToken && isAuthorizationPassed) {
             tokenInspection.addField("active", true);
+            tokenInspection.addField("roles", String.join(",", getUserRoles(user)));
         } else if (isAuthorizationPassed) {
             tokenInspection.addField("active", true);
-            ArrayList<String> roles = new ArrayList<>();
-            for (Privilege p : user.getTotalPrivilege()) {
-                roles.add(p.getName());
-            }
-            tokenInspection.addField("roles", String.join(",", roles));
+            tokenInspection.addField("roles", String.join(",", getUserRoles(user)));
 
             // Refresh token if expiring soon
             Date expiration = jws.getPayload().getExpiration();
@@ -228,7 +225,14 @@ public class TokenService {
         );
 
         return tokenInspection;
+    }
 
+    private static ArrayList<String> getUserRoles(User user) {
+        ArrayList<String> roles = new ArrayList<>();
+        for (Privilege p : user.getTotalPrivilege()) {
+            roles.add(p.getName());
+        }
+        return roles;
     }
 
     public RefreshToken refreshToken(String authorizationHeader) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * User profile responses now include a "roles" field (comma-separated) to surface assigned roles.
  * Long-term user tokens now carry a "roles" claim in the token payload.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->