### PR TITLE
Als 10196 fix roles

### DIFF
--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/entity/User.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/entity/User.java
@@ -141,7 +141,7 @@ public class User extends BaseEntity implements Serializable, Principal {
 		Set<Privilege> totalPrivilegeSet = getTotalPrivilege();
 
 		if (totalPrivilegeSet == null)
-			return null;
+			return Set.of();
 
 		Set<String> nameSet = new HashSet<>();
 		totalPrivilegeSet.forEach(p -> nameSet.add(p.getName()));

--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/entity/User.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/entity/User.java
@@ -158,7 +158,7 @@ public class User extends BaseEntity implements Serializable, Principal {
 		Set<Privilege> totalPrivilegeSet = getTotalPrivilege();
 
 		if (totalPrivilegeSet == null)
-			return null;
+			return Set.of();
 
 		Set<String> nameSet = new HashSet<>();
 		if (application == null)

--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/entity/User.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/entity/User.java
@@ -141,7 +141,7 @@ public class User extends BaseEntity implements Serializable, Principal {
 		Set<Privilege> totalPrivilegeSet = getTotalPrivilege();
 
 		if (totalPrivilegeSet == null)
-			return Set.of();
+			return new HashSet<>();
 
 		Set<String> nameSet = new HashSet<>();
 		totalPrivilegeSet.forEach(p -> nameSet.add(p.getName()));
@@ -158,7 +158,7 @@ public class User extends BaseEntity implements Serializable, Principal {
 		Set<Privilege> totalPrivilegeSet = getTotalPrivilege();
 
 		if (totalPrivilegeSet == null)
-			return Set.of();
+			return new HashSet<>();
 
 		Set<String> nameSet = new HashSet<>();
 		if (application == null)

--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/TokenService.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/TokenService.java
@@ -189,13 +189,10 @@ public class TokenService {
 
         if (isLongTermToken && isAuthorizationPassed) {
             tokenInspection.addField("active", true);
+            tokenInspection.addField("roles", String.join(",", getUserRoles(user)));
         } else if (isAuthorizationPassed) {
             tokenInspection.addField("active", true);
-            ArrayList<String> roles = new ArrayList<>();
-            for (Privilege p : user.getTotalPrivilege()) {
-                roles.add(p.getName());
-            }
-            tokenInspection.addField("roles", String.join(",", roles));
+            tokenInspection.addField("roles", String.join(",", getUserRoles(user)));
 
             // Refresh token if expiring soon
             Date expiration = jws.getPayload().getExpiration();
@@ -228,7 +225,14 @@ public class TokenService {
         );
 
         return tokenInspection;
+    }
 
+    private static ArrayList<String> getUserRoles(User user) {
+        ArrayList<String> roles = new ArrayList<>();
+        for (Privilege p : user.getTotalPrivilege()) {
+            roles.add(p.getName());
+        }
+        return roles;
     }
 
     public RefreshToken refreshToken(String authorizationHeader) {

--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/TokenService.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/TokenService.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import edu.harvard.hms.dbmi.avillach.auth.entity.Application;
 import edu.harvard.hms.dbmi.avillach.auth.entity.Privilege;
+import edu.harvard.hms.dbmi.avillach.auth.entity.Role;
 import edu.harvard.hms.dbmi.avillach.auth.entity.User;
 import edu.harvard.hms.dbmi.avillach.auth.exceptions.NotAuthorizedException;
 import edu.harvard.hms.dbmi.avillach.auth.model.*;
@@ -229,8 +230,8 @@ public class TokenService {
 
     private static ArrayList<String> getUserRoles(User user) {
         ArrayList<String> roles = new ArrayList<>();
-        for (Privilege p : user.getTotalPrivilege()) {
-            roles.add(p.getName());
+        for (Role role : user.getRoles()) {
+            roles.add(role.getName());
         }
         return roles;
     }

--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/TokenService.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/TokenService.java
@@ -229,6 +229,7 @@ public class TokenService {
     }
 
     private static ArrayList<String> getUserRoles(User user) {
+        logger.info("TokenService.getUserRoles: {}", user.getRoleString());
         ArrayList<String> roles = new ArrayList<>();
         for (Role role : user.getRoles()) {
             roles.add(role.getName());

--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/TokenService.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/TokenService.java
@@ -190,10 +190,8 @@ public class TokenService {
 
         if (isLongTermToken && isAuthorizationPassed) {
             tokenInspection.addField("active", true);
-            tokenInspection.addField("roles", String.join(",", getUserRoles(user)));
         } else if (isAuthorizationPassed) {
             tokenInspection.addField("active", true);
-            tokenInspection.addField("roles", String.join(",", getUserRoles(user)));
 
             // Refresh token if expiring soon
             Date expiration = jws.getPayload().getExpiration();
@@ -217,6 +215,7 @@ public class TokenService {
 
         // Include token payload and privileges
         tokenInspection.addAllFields(jws.getPayload());
+        tokenInspection.addField("roles", String.join(",", getUserRoles(user)));
         tokenInspection.addField("privileges", user.getPrivilegeNameSetByApplication(application));
 
         logger.debug(

--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/TokenService.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/TokenService.java
@@ -215,7 +215,7 @@ public class TokenService {
 
         // Include token payload and privileges
         tokenInspection.addAllFields(jws.getPayload());
-        tokenInspection.addField("roles", String.join(",", getUserRoles(user)));
+        tokenInspection.addField("roles", user.getRoleString());
         tokenInspection.addField("privileges", user.getPrivilegeNameSetByApplication(application));
 
         logger.debug(
@@ -225,15 +225,6 @@ public class TokenService {
         );
 
         return tokenInspection;
-    }
-
-    private static ArrayList<String> getUserRoles(User user) {
-        logger.info("TokenService.getUserRoles: {}", user.getRoleString());
-        ArrayList<String> roles = new ArrayList<>();
-        for (Role role : user.getRoles()) {
-            roles.add(role.getName());
-        }
-        return roles;
     }
 
     public RefreshToken refreshToken(String authorizationHeader) {

--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/TokenService.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/TokenService.java
@@ -216,7 +216,9 @@ public class TokenService {
         // Include token payload and privileges
         tokenInspection.addAllFields(jws.getPayload());
         tokenInspection.addField("roles", user.getRoleString());
-        tokenInspection.addField("privileges", user.getPrivilegeNameSetByApplication(application));
+        Set<String> userPrivileges = user.getPrivilegeNameSetByApplication(application);
+        userPrivileges.addAll(user.getPrivilegeNameSet());
+        tokenInspection.addField("privileges", userPrivileges);
 
         logger.debug(
             "_inspectToken() Successfully inspect and return response map: {}",

--- a/pic-sure-auth-services/src/test/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/TokenServiceTest.java
+++ b/pic-sure-auth-services/src/test/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/TokenServiceTest.java
@@ -93,7 +93,7 @@ public class TokenServiceTest {
         assertNull(response.get("message"));
         assertTrue((Boolean) response.get("active"));
         assertEquals(user.getSubject(), response.get("sub"));
-        assertEquals(application.getPrivileges(), response.get("privileges"));
+        assertEquals(user.getPrivilegeNameSet(), response.get("privileges"));
     }
 
     @Test
@@ -221,7 +221,7 @@ public class TokenServiceTest {
         assertNull(response.get("message"));
         assertTrue((Boolean) response.get("active"));
         assertEquals(AuthNaming.LONG_TERM_TOKEN_PREFIX + "|" + claims.get("sub").toString(), response.get("sub"));
-        assertEquals(application.getPrivileges(), response.get("privileges"));
+        assertEquals(user.getPrivilegeNameSet(), response.get("privileges"));
     }
 
     @Test


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Role determination during token validation and introspection now uses the user's stored role string instead of reconstructing roles from individual privileges.
  * Token introspection now reports privileges as the union of application-scoped and overall user privileges, providing a more complete privilege view after validation.

* **Bug Fix**
  * Privilege lookup now returns an empty set instead of null when no privileges exist, preventing null responses and related errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->