### PR TITLE
Verify and harden RAS passport handling (signature, IAL2, per-visa)

### DIFF
--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/model/ras/Passport.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/model/ras/Passport.java
@@ -2,6 +2,7 @@ package edu.harvard.hms.dbmi.avillach.auth.model.ras;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -19,7 +20,7 @@ public class Passport {
     private long exp;
 
     @JsonProperty("ga4gh_passport_v1")
-    private List<String> ga4ghPassportV1;
+    private List<String> ga4ghPassportV1 = new ArrayList<>();
 
     public String getSub() {
         return sub;
@@ -82,7 +83,7 @@ public class Passport {
     }
 
     public void setGa4ghPassportV1(List<String> ga4ghPassportV1) {
-        this.ga4ghPassportV1 = ga4ghPassportV1;
+        this.ga4ghPassportV1 = ga4ghPassportV1 != null ? ga4ghPassportV1 : new ArrayList<>();
     }
 
     @Override

--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/RASPassPortService.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/RASPassPortService.java
@@ -196,16 +196,15 @@ public class RASPassPortService {
         queryParams.add("visa", visa);
         HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(queryParams, null);
 
-        String responseVal = PassportValidationResponse.VISA_EXPIRED.getValue();
-        ResponseEntity<String> resp;
         try {
-            resp = this.restClientUtil.retrievePostResponse(this.rasURI + "/passport/validate", request);
-            responseVal = resp.getBody();
+            ResponseEntity<String> resp = this.restClientUtil.retrievePostResponse(this.rasURI + "/passport/validate", request);
+            return Optional.ofNullable(resp.getBody());
         } catch (Exception e) {
-            logger.error("validatePassport() FAILED TO VALIDATE VISA ___ {}", e.getMessage());
+            // A transport error is NOT a verdict. Returning empty makes the caller skip this visa
+            // rather than treat it as "Visa Expired" and force-log-out the user on a transient RAS blip.
+            logger.error("validatePassport() FAILED TO VALIDATE VISA (transient, skipping) ___ {}", e.getMessage());
+            return Optional.empty();
         }
-
-        return Optional.ofNullable(responseVal);
     }
 
     public Set<RasDbgapPermission> ga4ghPassportToRasDbgapPermissions(Set<Optional<Ga4ghPassportV1>> ga4ghPassports) {

--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/RASPassPortService.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/RASPassPortService.java
@@ -236,7 +236,6 @@ public class RASPassPortService {
     }
 
     public boolean isExpired(Passport passport) {
-        return passport.getExp() < System.currentTimeMillis() / 1000 &&
-                passport.getIat() < System.currentTimeMillis() / 1000;
+        return passport.getExp() < System.currentTimeMillis() / 1000;
     }
 }

--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/RASPassPortService.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/RASPassPortService.java
@@ -104,6 +104,9 @@ public class RASPassPortService {
         }
 
         List<String> ga4ghPassportV1 = passportOptional.get().getGa4ghPassportV1();
+        boolean anyValidated = false;
+        // Validate EVERY visa. A single invalid visa invalidates the passport; we must not stop at the
+        // first one that happens to be valid.
         for (String visa : ga4ghPassportV1) {
             Optional<Ga4ghPassportV1> parsedVisa = JWTUtil.parseGa4ghPassportV1(visa);
             if (parsedVisa.isEmpty()) {
@@ -124,11 +127,14 @@ public class RASPassPortService {
                     logger.info("PASSPORT VALIDATION COMPLETE __ PASSPORT IS NO LONGER VALID ___ USER {} ___ USER LOGGED OUT", user.getSubject());
                     sendInvalidatedEvent(user.getSubject(), response.get());
                     return ValidationOutcome.INVALIDATED;
-                } else {
-                    logger.info("PASSPORT VALIDATION COMPLETE __ PASSPORT IS VALID ___ USER {}", user.getSubject());
-                    return ValidationOutcome.VALIDATED;
                 }
+                anyValidated = true;
             }
+        }
+
+        if (anyValidated) {
+            logger.info("PASSPORT VALIDATION COMPLETE __ PASSPORT IS VALID ___ USER {}", user.getSubject());
+            return ValidationOutcome.VALIDATED;
         }
 
         return ValidationOutcome.SKIPPED;

--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/RasPassportSignatureVerifier.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/RasPassportSignatureVerifier.java
@@ -1,0 +1,149 @@
+package edu.harvard.hms.dbmi.avillach.auth.service.impl;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import edu.harvard.hms.dbmi.avillach.auth.utils.RestClientUtil;
+import io.jsonwebtoken.Jwts;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+
+import java.math.BigInteger;
+import java.security.KeyFactory;
+import java.security.PublicKey;
+import java.security.spec.RSAPublicKeySpec;
+import java.util.Base64;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Cryptographically verifies the RS256 signature of RAS passport / GA4GH visa JWTs against the
+ * public keys RAS publishes at its JWKS endpoint.
+ *
+ * <p>Because Okta brokers the RAS connection, PIC-SURE never talks to RAS directly. Signature
+ * verification against RAS's JWKS is therefore the only thing that guarantees the dbGaP permissions
+ * carried in a passport were issued by RAS and were not tampered with anywhere in the Okta hop. The
+ * keys are discovered via standard OIDC metadata ({@code <issuer>/.well-known/openid-configuration}
+ * -> {@code jwks_uri}) and cached by {@code kid}; an unknown {@code kid} triggers a refresh to pick
+ * up RAS key rotation.</p>
+ */
+@Service
+public class RasPassportSignatureVerifier {
+
+    private final Logger logger = LoggerFactory.getLogger(RasPassportSignatureVerifier.class);
+
+    private final RestClientUtil restClientUtil;
+    private final String issuer;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final Map<String, PublicKey> keyCache = new ConcurrentHashMap<>();
+
+    @Autowired
+    public RasPassportSignatureVerifier(RestClientUtil restClientUtil,
+                                        @Value("${ras.passport.issuer}") String rasPassportIssuer) {
+        this.restClientUtil = restClientUtil;
+        this.issuer = rasPassportIssuer == null ? null : rasPassportIssuer.replaceAll("/$", "");
+        logger.info("RasPassportSignatureVerifier initialized with issuer: {}", this.issuer);
+    }
+
+    /**
+     * @param jwt an encoded RAS passport or GA4GH visa JWT (header.payload.signature)
+     * @return true only if the signature verifies against RAS's published JWKS key for the token's
+     * {@code kid}. Returns false for a missing/blank token, an unknown {@code kid}, a malformed token,
+     * an expired token, or any signature mismatch. Fails closed: any error means "not valid".
+     */
+    public boolean isSignatureValid(String jwt) {
+        if (StringUtils.isBlank(jwt)) {
+            logger.error("isSignatureValid() rejecting blank passport token");
+            return false;
+        }
+
+        try {
+            String kid = extractKid(jwt);
+            PublicKey key = resolveKey(kid);
+            if (key == null) {
+                logger.error("isSignatureValid() rejecting passport - no RAS JWKS key found for kid {}", kid);
+                return false;
+            }
+
+            Jwts.parser().verifyWith(key).build().parseSignedClaims(jwt);
+            return true;
+        } catch (Exception e) {
+            logger.error("isSignatureValid() rejecting passport - {}: {}", e.getClass().getSimpleName(), e.getMessage());
+            return false;
+        }
+    }
+
+    private String extractKid(String jwt) throws Exception {
+        String[] parts = jwt.split("\\.");
+        if (parts.length != 3) {
+            throw new IllegalArgumentException("token is not a JWS (expected 3 segments)");
+        }
+        JsonNode header = objectMapper.readTree(Base64.getUrlDecoder().decode(parts[0]));
+        JsonNode kid = header.get("kid");
+        return kid == null ? null : kid.asText();
+    }
+
+    private PublicKey resolveKey(String kid) {
+        if (kid == null) {
+            return null;
+        }
+        PublicKey cached = keyCache.get(kid);
+        if (cached != null) {
+            return cached;
+        }
+        // Unknown kid: refresh once to pick up rotated RAS keys, then look again.
+        refreshKeys();
+        return keyCache.get(kid);
+    }
+
+    private synchronized void refreshKeys() {
+        try {
+            String jwksUri = discoverJwksUri();
+            ResponseEntity<String> response = restClientUtil.retrieveGetResponse(jwksUri, new HttpHeaders());
+            JsonNode keys = objectMapper.readTree(response.getBody()).get("keys");
+            if (keys == null) {
+                logger.error("refreshKeys() RAS JWKS response had no 'keys' array");
+                return;
+            }
+
+            for (JsonNode jwk : keys) {
+                if (!"RSA".equals(text(jwk, "kty"))) {
+                    continue;
+                }
+                String kid = text(jwk, "kid");
+                String n = text(jwk, "n");
+                String e = text(jwk, "e");
+                if (kid == null || n == null || e == null) {
+                    continue;
+                }
+                BigInteger modulus = new BigInteger(1, Base64.getUrlDecoder().decode(n));
+                BigInteger exponent = new BigInteger(1, Base64.getUrlDecoder().decode(e));
+                PublicKey key = KeyFactory.getInstance("RSA").generatePublic(new RSAPublicKeySpec(modulus, exponent));
+                keyCache.put(kid, key);
+            }
+        } catch (Exception ex) {
+            logger.error("refreshKeys() failed to load RAS JWKS - {}: {}", ex.getClass().getSimpleName(), ex.getMessage());
+        }
+    }
+
+    private String discoverJwksUri() throws Exception {
+        ResponseEntity<String> response =
+                restClientUtil.retrieveGetResponse(issuer + "/.well-known/openid-configuration", new HttpHeaders());
+        JsonNode config = objectMapper.readTree(response.getBody());
+        JsonNode jwksUri = config.get("jwks_uri");
+        if (jwksUri == null) {
+            throw new IllegalStateException("RAS OIDC discovery document has no jwks_uri");
+        }
+        return jwksUri.asText();
+    }
+
+    private static String text(JsonNode node, String field) {
+        JsonNode value = node.get(field);
+        return value == null ? null : value.asText();
+    }
+}

--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/RasPassportSignatureVerifier.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/RasPassportSignatureVerifier.java
@@ -2,21 +2,25 @@ package edu.harvard.hms.dbmi.avillach.auth.service.impl;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import edu.harvard.hms.dbmi.avillach.auth.utils.RestClientUtil;
 import io.jsonwebtoken.Jwts;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
 import java.math.BigInteger;
+import java.net.InetSocketAddress;
+import java.net.ProxySelector;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
 import java.security.KeyFactory;
 import java.security.PublicKey;
 import java.security.spec.RSAPublicKeySpec;
+import java.time.Duration;
 import java.util.Base64;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -27,26 +31,37 @@ import java.util.concurrent.ConcurrentHashMap;
  *
  * <p>Because Okta brokers the RAS connection, PIC-SURE never talks to RAS directly. Signature
  * verification against RAS's JWKS is therefore the only thing that guarantees the dbGaP permissions
- * carried in a passport were issued by RAS and were not tampered with anywhere in the Okta hop. The
- * keys are discovered via standard OIDC metadata ({@code <issuer>/.well-known/openid-configuration}
- * -> {@code jwks_uri}) and cached by {@code kid}; an unknown {@code kid} triggers a refresh to pick
- * up RAS key rotation.</p>
+ * carried in a passport were issued by RAS and were not tampered with in the Okta hop. The keys are
+ * discovered via standard OIDC metadata ({@code <issuer>/.well-known/openid-configuration} ->
+ * {@code jwks_uri}) and cached by {@code kid}; an unknown {@code kid} triggers a refresh to pick up
+ * RAS key rotation.</p>
+ *
+ * <p>The discovery and JWKS documents are fetched with the JDK {@link HttpClient} negotiating
+ * HTTP/2. The shared Apache HttpClient5 {@code RestTemplate} is HTTP/1.1-only, and the NIH gateway
+ * truncates responses on that path (the body is cut short mid-stream), which made every passport
+ * fail signature verification. The JDK client behaves like {@code curl} and reads the full body.</p>
  */
 @Service
 public class RasPassportSignatureVerifier {
 
     private final Logger logger = LoggerFactory.getLogger(RasPassportSignatureVerifier.class);
 
-    private final RestClientUtil restClientUtil;
     private final String issuer;
     private final ObjectMapper objectMapper = new ObjectMapper();
     private final Map<String, PublicKey> keyCache = new ConcurrentHashMap<>();
+    private final UrlFetcher urlFetcher;
 
     @Autowired
-    public RasPassportSignatureVerifier(RestClientUtil restClientUtil,
-                                        @Value("${ras.passport.issuer}") String rasPassportIssuer) {
-        this.restClientUtil = restClientUtil;
+    public RasPassportSignatureVerifier(@Value("${ras.passport.issuer}") String rasPassportIssuer,
+                                        @Value("${http.proxyHost:}") String proxyHost,
+                                        @Value("${http.proxyPort:8080}") int proxyPort) {
+        this(rasPassportIssuer, defaultFetcher(proxyHost, proxyPort));
+    }
+
+    /** Package-private constructor allowing tests to supply a canned fetcher (no real HTTP). */
+    RasPassportSignatureVerifier(String rasPassportIssuer, UrlFetcher urlFetcher) {
         this.issuer = rasPassportIssuer == null ? null : rasPassportIssuer.replaceAll("/$", "");
+        this.urlFetcher = urlFetcher;
         logger.info("RasPassportSignatureVerifier initialized with issuer: {}", this.issuer);
     }
 
@@ -105,8 +120,7 @@ public class RasPassportSignatureVerifier {
         String jwksUri = null;
         try {
             jwksUri = discoverJwksUri();
-            ResponseEntity<String> response = restClientUtil.retrieveGetResponse(jwksUri, new HttpHeaders());
-            String body = logFetchDiagnostics("JWKS", jwksUri, response);
+            String body = fetchBody("JWKS", jwksUri);
             JsonNode keys = objectMapper.readTree(body).get("keys");
             if (keys == null) {
                 logger.error("refreshKeys() RAS JWKS response had no 'keys' array");
@@ -136,8 +150,7 @@ public class RasPassportSignatureVerifier {
 
     private String discoverJwksUri() throws Exception {
         String discoveryUrl = issuer + "/.well-known/openid-configuration";
-        ResponseEntity<String> response = restClientUtil.retrieveGetResponse(discoveryUrl, new HttpHeaders());
-        String body = logFetchDiagnostics("OIDC discovery", discoveryUrl, response);
+        String body = fetchBody("OIDC discovery", discoveryUrl);
         JsonNode config = objectMapper.readTree(body);
         JsonNode jwksUri = config.get("jwks_uri");
         if (jwksUri == null) {
@@ -147,27 +160,57 @@ public class RasPassportSignatureVerifier {
     }
 
     /**
-     * Logs what we actually received for a RAS fetch so transport problems (truncation, compression,
-     * proxy interference) are diagnosable without enabling DEBUG. Compare bodyLength against the
-     * Content-Length header: a mismatch means the response was truncated before our JSON parser saw
-     * it. The discovery/JWKS documents contain only public data (no secrets), so logging the body is
-     * safe. Capped at 2048 chars to bound log size.
+     * Fetches a URL and logs what we actually received at INFO (no DEBUG required) so transport
+     * problems (truncation, wrong Content-Length, HTTP version) are diagnosable. The discovery/JWKS
+     * documents are public (no secrets), so logging the body is safe; capped at 2048 chars.
      */
-    private String logFetchDiagnostics(String what, String url, ResponseEntity<String> response) {
-        String body = response.getBody();
-        String snippet = body == null ? "null" : body.substring(0, Math.min(2048, body.length()));
-        logger.info("RAS {} fetch: url={} status={} contentLengthHeader={} contentEncoding={} transferEncoding={} bodyLength={} body={}",
-                what, url, response.getStatusCode(),
-                response.getHeaders().getFirst("Content-Length"),
-                response.getHeaders().getFirst("Content-Encoding"),
-                response.getHeaders().getFirst("Transfer-Encoding"),
+    private String fetchBody(String what, String url) throws Exception {
+        FetchResult result = urlFetcher.fetch(url);
+        String body = result.body();
+        logger.info("RAS {} fetch: url={} status={} httpVersion={} contentLength={} bodyLength={} body={}",
+                what, url, result.status(), result.httpVersion(), result.contentLengthHeader(),
                 body == null ? "null" : body.length(),
-                snippet);
+                body == null ? "null" : body.substring(0, Math.min(2048, body.length())));
         return body;
+    }
+
+    private static UrlFetcher defaultFetcher(String proxyHost, int proxyPort) {
+        HttpClient.Builder builder = HttpClient.newBuilder()
+                .version(HttpClient.Version.HTTP_2)
+                .followRedirects(HttpClient.Redirect.NORMAL)
+                .connectTimeout(Duration.ofSeconds(10));
+        if (StringUtils.isNotBlank(proxyHost)) {
+            builder.proxy(ProxySelector.of(new InetSocketAddress(proxyHost, proxyPort)));
+        }
+        HttpClient client = builder.build();
+
+        return url -> {
+            HttpRequest request = HttpRequest.newBuilder(URI.create(url))
+                    .header("Accept", "application/json")
+                    .timeout(Duration.ofSeconds(15))
+                    .GET()
+                    .build();
+            HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+            return new FetchResult(
+                    response.statusCode(),
+                    String.valueOf(response.version()),
+                    response.headers().firstValue("content-length").orElse(null),
+                    response.body());
+        };
     }
 
     private static String text(JsonNode node, String field) {
         JsonNode value = node.get(field);
         return value == null ? null : value.asText();
+    }
+
+    /** Seam for fetching a URL's body, so tests can supply canned responses without real HTTP. */
+    @FunctionalInterface
+    interface UrlFetcher {
+        FetchResult fetch(String url) throws Exception;
+    }
+
+    /** Minimal HTTP response shape needed for verification and diagnostics. */
+    record FetchResult(int status, String httpVersion, String contentLengthHeader, String body) {
     }
 }

--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/RasPassportSignatureVerifier.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/RasPassportSignatureVerifier.java
@@ -148,21 +148,21 @@ public class RasPassportSignatureVerifier {
 
     /**
      * Logs what we actually received for a RAS fetch so transport problems (truncation, compression,
-     * proxy interference) are diagnosable. Compare bodyLength against the Content-Length header: a
-     * mismatch means the response was truncated before our JSON parser saw it.
+     * proxy interference) are diagnosable without enabling DEBUG. Compare bodyLength against the
+     * Content-Length header: a mismatch means the response was truncated before our JSON parser saw
+     * it. The discovery/JWKS documents contain only public data (no secrets), so logging the body is
+     * safe. Capped at 2048 chars to bound log size.
      */
     private String logFetchDiagnostics(String what, String url, ResponseEntity<String> response) {
         String body = response.getBody();
-        logger.info("RAS {} fetch: url={} status={} contentLengthHeader={} contentEncoding={} transferEncoding={} bodyLength={}",
+        String snippet = body == null ? "null" : body.substring(0, Math.min(2048, body.length()));
+        logger.info("RAS {} fetch: url={} status={} contentLengthHeader={} contentEncoding={} transferEncoding={} bodyLength={} body={}",
                 what, url, response.getStatusCode(),
                 response.getHeaders().getFirst("Content-Length"),
                 response.getHeaders().getFirst("Content-Encoding"),
                 response.getHeaders().getFirst("Transfer-Encoding"),
-                body == null ? "null" : body.length());
-        if (logger.isDebugEnabled()) {
-            logger.debug("RAS {} body (first 300 chars): {}", what,
-                    body == null ? "null" : body.substring(0, Math.min(300, body.length())));
-        }
+                body == null ? "null" : body.length(),
+                snippet);
         return body;
     }
 

--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/RasPassportSignatureVerifier.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/RasPassportSignatureVerifier.java
@@ -120,8 +120,7 @@ public class RasPassportSignatureVerifier {
         String jwksUri = null;
         try {
             jwksUri = discoverJwksUri();
-            String body = fetchBody("JWKS", jwksUri);
-            JsonNode keys = objectMapper.readTree(body).get("keys");
+            JsonNode keys = fetchJson("JWKS", jwksUri).get("keys");
             if (keys == null) {
                 logger.error("refreshKeys() RAS JWKS response had no 'keys' array");
                 return;
@@ -150,8 +149,7 @@ public class RasPassportSignatureVerifier {
 
     private String discoverJwksUri() throws Exception {
         String discoveryUrl = issuer + "/.well-known/openid-configuration";
-        String body = fetchBody("OIDC discovery", discoveryUrl);
-        JsonNode config = objectMapper.readTree(body);
+        JsonNode config = fetchJson("OIDC discovery", discoveryUrl);
         JsonNode jwksUri = config.get("jwks_uri");
         if (jwksUri == null) {
             throw new IllegalStateException("RAS OIDC discovery document has no jwks_uri at " + discoveryUrl);
@@ -160,18 +158,28 @@ public class RasPassportSignatureVerifier {
     }
 
     /**
-     * Fetches a URL and logs what we actually received at INFO (no DEBUG required) so transport
-     * problems (truncation, wrong Content-Length, HTTP version) are diagnosable. The discovery/JWKS
-     * documents are public (no secrets), so logging the body is safe; capped at 2048 chars.
+     * Fetches a URL and parses it as JSON. Logs status / HTTP version / Content-Length / body length
+     * at INFO on every fetch so a transport problem (a truncated body, a wrong Content-Length, an
+     * unexpected HTTP version) is visible without enabling DEBUG. Only when the body fails to parse
+     * do we log the body itself (capped at 2048 chars) - it is public data and that is the one time
+     * it is actually needed to diagnose.
      */
-    private String fetchBody(String what, String url) throws Exception {
+    private JsonNode fetchJson(String what, String url) throws Exception {
         FetchResult result = urlFetcher.fetch(url);
         String body = result.body();
-        logger.info("RAS {} fetch: url={} status={} httpVersion={} contentLength={} bodyLength={} body={}",
+        logger.info("RAS {} fetch: url={} status={} httpVersion={} contentLength={} bodyLength={}",
                 what, url, result.status(), result.httpVersion(), result.contentLengthHeader(),
-                body == null ? "null" : body.length(),
-                body == null ? "null" : body.substring(0, Math.min(2048, body.length())));
-        return body;
+                body == null ? "null" : body.length());
+        try {
+            return objectMapper.readTree(body);
+        } catch (Exception e) {
+            logger.error("RAS {} fetch from {} returned an unparseable body (status={} contentLength={} bodyLength={}) - "
+                            + "likely truncated or non-JSON. Body: {}",
+                    what, url, result.status(), result.contentLengthHeader(),
+                    body == null ? "null" : body.length(),
+                    body == null ? "null" : body.substring(0, Math.min(2048, body.length())));
+            throw e;
+        }
     }
 
     private static UrlFetcher defaultFetcher(String proxyHost, int proxyPort) {

--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/RasPassportSignatureVerifier.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/RasPassportSignatureVerifier.java
@@ -12,7 +12,6 @@ import org.springframework.stereotype.Service;
 
 import java.math.BigInteger;
 import java.net.InetSocketAddress;
-import java.net.ProxySelector;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
@@ -22,8 +21,9 @@ import java.security.PublicKey;
 import java.security.spec.RSAPublicKeySpec;
 import java.time.Duration;
 import java.util.Base64;
+import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.LongSupplier;
 
 /**
  * Cryptographically verifies the RS256 signature of RAS passport / GA4GH visa JWTs against the
@@ -31,25 +31,42 @@ import java.util.concurrent.ConcurrentHashMap;
  *
  * <p>Because Okta brokers the RAS connection, PIC-SURE never talks to RAS directly. Signature
  * verification against RAS's JWKS is therefore the only thing that guarantees the dbGaP permissions
- * carried in a passport were issued by RAS and were not tampered with in the Okta hop. The keys are
+ * carried in a passport were issued by RAS and were not tampered with in the Okta hop. Keys are
  * discovered via standard OIDC metadata ({@code <issuer>/.well-known/openid-configuration} ->
- * {@code jwks_uri}) and cached by {@code kid}; an unknown {@code kid} triggers a refresh to pick up
- * RAS key rotation.</p>
+ * {@code jwks_uri}) and cached by {@code kid}.</p>
  *
- * <p>The discovery and JWKS documents are fetched with the JDK {@link HttpClient} negotiating
- * HTTP/2. The shared Apache HttpClient5 {@code RestTemplate} is HTTP/1.1-only, and the NIH gateway
- * truncates responses on that path (the body is cut short mid-stream), which made every passport
- * fail signature verification. The JDK client behaves like {@code curl} and reads the full body.</p>
+ * <p>Cache discipline:
+ * <ul>
+ *   <li>The discovered {@code jwks_uri} is cached so a key refresh is a single round trip, not two.</li>
+ *   <li>An unknown {@code kid} triggers at most one refresh per {@link #REFRESH_THROTTLE_MS} window,
+ *       so a flood of tokens bearing keys RAS never published cannot turn into a JWKS refetch storm.</li>
+ *   <li>The whole key set is re-pulled at least every {@link #CACHE_TTL_MS} so a key RAS rotates out
+ *       (or revokes while reusing its {@code kid}) stops being trusted.</li>
+ * </ul>
+ * The HTTP fetch uses the JDK {@link HttpClient} negotiating HTTP/2, because the shared Apache
+ * HttpClient5 {@code RestTemplate} is HTTP/1.1-only and the NIH gateway truncates responses on that
+ * path.</p>
  */
 @Service
 public class RasPassportSignatureVerifier {
+
+    private static final String RS256 = "RS256";
+    /** Do not refetch the JWKS more than once per this window, even on repeated unknown-kid misses. */
+    static final long REFRESH_THROTTLE_MS = 60_000L;
+    /** Re-pull the JWKS at least this often so rotated-out / revoked keys stop being trusted. */
+    static final long CACHE_TTL_MS = 3_600_000L;
 
     private final Logger logger = LoggerFactory.getLogger(RasPassportSignatureVerifier.class);
 
     private final String issuer;
     private final ObjectMapper objectMapper = new ObjectMapper();
-    private final Map<String, PublicKey> keyCache = new ConcurrentHashMap<>();
     private final UrlFetcher urlFetcher;
+    private final LongSupplier clock;
+
+    private volatile Map<String, PublicKey> keyCache = Map.of();
+    private volatile String cachedJwksUri;
+    private volatile long lastRefreshAttemptMs;
+    private volatile long lastSuccessfulRefreshMs;
 
     @Autowired
     public RasPassportSignatureVerifier(@Value("${ras.passport.issuer}") String rasPassportIssuer,
@@ -60,16 +77,28 @@ public class RasPassportSignatureVerifier {
 
     /** Package-private constructor allowing tests to supply a canned fetcher (no real HTTP). */
     RasPassportSignatureVerifier(String rasPassportIssuer, UrlFetcher urlFetcher) {
+        this(rasPassportIssuer, urlFetcher, System::currentTimeMillis);
+    }
+
+    /** Package-private constructor allowing tests to control time (for throttle / TTL behavior). */
+    RasPassportSignatureVerifier(String rasPassportIssuer, UrlFetcher urlFetcher, LongSupplier clock) {
         this.issuer = rasPassportIssuer == null ? null : rasPassportIssuer.replaceAll("/$", "");
         this.urlFetcher = urlFetcher;
-        logger.info("RasPassportSignatureVerifier initialized with issuer: {}", this.issuer);
+        this.clock = clock;
+        if (StringUtils.isBlank(this.issuer) || "false".equalsIgnoreCase(this.issuer)) {
+            logger.warn("RasPassportSignatureVerifier: ras.passport.issuer is not configured (value='{}'); "
+                    + "RAS passport signature verification WILL FAIL until it is set to the RAS STS issuer.", this.issuer);
+        } else {
+            logger.info("RasPassportSignatureVerifier initialized with issuer: {}", this.issuer);
+        }
     }
 
     /**
      * @param jwt an encoded RAS passport or GA4GH visa JWT (header.payload.signature)
-     * @return true only if the signature verifies against RAS's published JWKS key for the token's
-     * {@code kid}. Returns false for a missing/blank token, an unknown {@code kid}, a malformed token,
-     * an expired token, or any signature mismatch. Fails closed: any error means "not valid".
+     * @return true only if the token is RS256-signed and its signature verifies against RAS's published
+     * JWKS key for the token's {@code kid}. Returns false for a missing/blank token, a non-RS256 alg,
+     * an unknown {@code kid}, a malformed token, an expired token, or any signature mismatch. Fails
+     * closed: any error means "not valid".
      */
     public boolean isSignatureValid(String jwt) {
         if (StringUtils.isBlank(jwt)) {
@@ -78,10 +107,15 @@ public class RasPassportSignatureVerifier {
         }
 
         try {
-            String kid = extractKid(jwt);
-            PublicKey key = resolveKey(kid);
+            JsonNode header = parseHeader(jwt);
+            String alg = text(header, "alg");
+            if (!RS256.equals(alg)) {
+                logger.error("isSignatureValid() rejecting passport - unexpected JWS alg {} (only RS256 is accepted)", alg);
+                return false;
+            }
+            PublicKey key = resolveKey(text(header, "kid"));
             if (key == null) {
-                logger.error("isSignatureValid() rejecting passport - no RAS JWKS key found for kid {}", kid);
+                logger.error("isSignatureValid() rejecting passport - no RAS JWKS key found for kid {}", text(header, "kid"));
                 return false;
             }
 
@@ -93,39 +127,48 @@ public class RasPassportSignatureVerifier {
         }
     }
 
-    private String extractKid(String jwt) throws Exception {
+    private JsonNode parseHeader(String jwt) throws Exception {
         String[] parts = jwt.split("\\.");
         if (parts.length != 3) {
             throw new IllegalArgumentException("token is not a JWS (expected 3 segments)");
         }
-        JsonNode header = objectMapper.readTree(Base64.getUrlDecoder().decode(parts[0]));
-        JsonNode kid = header.get("kid");
-        return kid == null ? null : kid.asText();
+        return objectMapper.readTree(Base64.getUrlDecoder().decode(parts[0]));
     }
 
     private PublicKey resolveKey(String kid) {
         if (kid == null) {
             return null;
         }
+        long now = clock.getAsLong();
         PublicKey cached = keyCache.get(kid);
-        if (cached != null) {
+        boolean stale = (now - lastSuccessfulRefreshMs) > CACHE_TTL_MS;
+        if (cached != null && !stale) {
             return cached;
         }
-        // Unknown kid: refresh once to pick up rotated RAS keys, then look again.
-        refreshKeys();
+        maybeRefreshKeys(now);
         return keyCache.get(kid);
     }
 
-    private synchronized void refreshKeys() {
-        String jwksUri = null;
+    private synchronized void maybeRefreshKeys(long now) {
+        // Throttle: a kid that is simply absent (rotated/forged/stale) must not refetch on every call.
+        if (now - lastRefreshAttemptMs < REFRESH_THROTTLE_MS && lastRefreshAttemptMs != 0L) {
+            return;
+        }
+        lastRefreshAttemptMs = now;
         try {
-            jwksUri = discoverJwksUri();
+            String jwksUri = cachedJwksUri;
+            if (jwksUri == null) {
+                jwksUri = discoverJwksUri();
+                cachedJwksUri = jwksUri;
+            }
+
             JsonNode keys = fetchJson("JWKS", jwksUri).get("keys");
             if (keys == null) {
-                logger.error("refreshKeys() RAS JWKS response had no 'keys' array");
+                logger.error("maybeRefreshKeys() RAS JWKS response had no 'keys' array");
                 return;
             }
 
+            Map<String, PublicKey> fresh = new HashMap<>();
             for (JsonNode jwk : keys) {
                 if (!"RSA".equals(text(jwk, "kty"))) {
                     continue;
@@ -136,14 +179,19 @@ public class RasPassportSignatureVerifier {
                 if (kid == null || n == null || e == null) {
                     continue;
                 }
-                BigInteger modulus = new BigInteger(1, Base64.getUrlDecoder().decode(n));
-                BigInteger exponent = new BigInteger(1, Base64.getUrlDecoder().decode(e));
-                PublicKey key = KeyFactory.getInstance("RSA").generatePublic(new RSAPublicKeySpec(modulus, exponent));
-                keyCache.put(kid, key);
+                fresh.put(kid, toRsaPublicKey(n, e));
+            }
+
+            if (!fresh.isEmpty()) {
+                // Replace (not merge) so keys RAS no longer publishes are dropped.
+                keyCache = Map.copyOf(fresh);
+                lastSuccessfulRefreshMs = now;
             }
         } catch (Exception ex) {
-            logger.error("refreshKeys() failed to load RAS JWKS from {} - {}: {}",
-                    jwksUri, ex.getClass().getSimpleName(), ex.getMessage());
+            // Re-discover next time in case jwks_uri itself changed. Keep the existing cache so a
+            // transient JWKS outage does not reject users whose key we already hold.
+            cachedJwksUri = null;
+            logger.error("maybeRefreshKeys() failed to load RAS JWKS - {}: {}", ex.getClass().getSimpleName(), ex.getMessage());
         }
     }
 
@@ -157,12 +205,17 @@ public class RasPassportSignatureVerifier {
         return jwksUri.asText();
     }
 
+    private static PublicKey toRsaPublicKey(String n, String e) throws Exception {
+        BigInteger modulus = new BigInteger(1, Base64.getUrlDecoder().decode(n));
+        BigInteger exponent = new BigInteger(1, Base64.getUrlDecoder().decode(e));
+        return KeyFactory.getInstance("RSA").generatePublic(new RSAPublicKeySpec(modulus, exponent));
+    }
+
     /**
      * Fetches a URL and parses it as JSON. Logs status / HTTP version / Content-Length / body length
      * at INFO on every fetch so a transport problem (a truncated body, a wrong Content-Length, an
-     * unexpected HTTP version) is visible without enabling DEBUG. Only when the body fails to parse
-     * do we log the body itself (capped at 2048 chars) - it is public data and that is the one time
-     * it is actually needed to diagnose.
+     * unexpected HTTP version) is visible without enabling DEBUG. A non-2xx status is rejected, and
+     * only when the body fails to parse do we log the body itself (capped at 2048 chars).
      */
     private JsonNode fetchJson(String what, String url) throws Exception {
         FetchResult result = urlFetcher.fetch(url);
@@ -170,6 +223,9 @@ public class RasPassportSignatureVerifier {
         logger.info("RAS {} fetch: url={} status={} httpVersion={} contentLength={} bodyLength={}",
                 what, url, result.status(), result.httpVersion(), result.contentLengthHeader(),
                 body == null ? "null" : body.length());
+        if (result.status() < 200 || result.status() >= 300) {
+            throw new IllegalStateException("RAS " + what + " fetch returned HTTP status " + result.status());
+        }
         try {
             return objectMapper.readTree(body);
         } catch (Exception e) {
@@ -188,7 +244,7 @@ public class RasPassportSignatureVerifier {
                 .followRedirects(HttpClient.Redirect.NORMAL)
                 .connectTimeout(Duration.ofSeconds(10));
         if (StringUtils.isNotBlank(proxyHost)) {
-            builder.proxy(ProxySelector.of(new InetSocketAddress(proxyHost, proxyPort)));
+            builder.proxy(java.net.ProxySelector.of(new InetSocketAddress(proxyHost, proxyPort)));
         }
         HttpClient client = builder.build();
 
@@ -209,7 +265,7 @@ public class RasPassportSignatureVerifier {
 
     private static String text(JsonNode node, String field) {
         JsonNode value = node.get(field);
-        return value == null ? null : value.asText();
+        return (value == null || value.isNull()) ? null : value.asText();
     }
 
     /** Seam for fetching a URL's body, so tests can supply canned responses without real HTTP. */

--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/RasPassportSignatureVerifier.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/RasPassportSignatureVerifier.java
@@ -102,10 +102,12 @@ public class RasPassportSignatureVerifier {
     }
 
     private synchronized void refreshKeys() {
+        String jwksUri = null;
         try {
-            String jwksUri = discoverJwksUri();
+            jwksUri = discoverJwksUri();
             ResponseEntity<String> response = restClientUtil.retrieveGetResponse(jwksUri, new HttpHeaders());
-            JsonNode keys = objectMapper.readTree(response.getBody()).get("keys");
+            String body = logFetchDiagnostics("JWKS", jwksUri, response);
+            JsonNode keys = objectMapper.readTree(body).get("keys");
             if (keys == null) {
                 logger.error("refreshKeys() RAS JWKS response had no 'keys' array");
                 return;
@@ -127,19 +129,41 @@ public class RasPassportSignatureVerifier {
                 keyCache.put(kid, key);
             }
         } catch (Exception ex) {
-            logger.error("refreshKeys() failed to load RAS JWKS - {}: {}", ex.getClass().getSimpleName(), ex.getMessage());
+            logger.error("refreshKeys() failed to load RAS JWKS from {} - {}: {}",
+                    jwksUri, ex.getClass().getSimpleName(), ex.getMessage());
         }
     }
 
     private String discoverJwksUri() throws Exception {
-        ResponseEntity<String> response =
-                restClientUtil.retrieveGetResponse(issuer + "/.well-known/openid-configuration", new HttpHeaders());
-        JsonNode config = objectMapper.readTree(response.getBody());
+        String discoveryUrl = issuer + "/.well-known/openid-configuration";
+        ResponseEntity<String> response = restClientUtil.retrieveGetResponse(discoveryUrl, new HttpHeaders());
+        String body = logFetchDiagnostics("OIDC discovery", discoveryUrl, response);
+        JsonNode config = objectMapper.readTree(body);
         JsonNode jwksUri = config.get("jwks_uri");
         if (jwksUri == null) {
-            throw new IllegalStateException("RAS OIDC discovery document has no jwks_uri");
+            throw new IllegalStateException("RAS OIDC discovery document has no jwks_uri at " + discoveryUrl);
         }
         return jwksUri.asText();
+    }
+
+    /**
+     * Logs what we actually received for a RAS fetch so transport problems (truncation, compression,
+     * proxy interference) are diagnosable. Compare bodyLength against the Content-Length header: a
+     * mismatch means the response was truncated before our JSON parser saw it.
+     */
+    private String logFetchDiagnostics(String what, String url, ResponseEntity<String> response) {
+        String body = response.getBody();
+        logger.info("RAS {} fetch: url={} status={} contentLengthHeader={} contentEncoding={} transferEncoding={} bodyLength={}",
+                what, url, response.getStatusCode(),
+                response.getHeaders().getFirst("Content-Length"),
+                response.getHeaders().getFirst("Content-Encoding"),
+                response.getHeaders().getFirst("Transfer-Encoding"),
+                body == null ? "null" : body.length());
+        if (logger.isDebugEnabled()) {
+            logger.debug("RAS {} body (first 300 chars): {}", what,
+                    body == null ? "null" : body.substring(0, Math.min(300, body.length())));
+        }
+        return body;
     }
 
     private static String text(JsonNode node, String field) {

--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/authentication/RASAuthenticationService.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/authentication/RASAuthenticationService.java
@@ -36,6 +36,7 @@ public class RASAuthenticationService extends OktaAuthenticationService implemen
     private final CacheEvictionService cacheEvictionService;
     private Connection rasConnection;
     private final String rasPassportIssuer;
+    private final boolean enforceIal2;
 
     /**
      * Constructor for the RASAuthenticationService
@@ -55,6 +56,7 @@ public class RASAuthenticationService extends OktaAuthenticationService implemen
                                     @Value("${ras.okta.client.id}") String clientId,
                                     @Value("${ras.okta.client.secret}") String clientSecret,
                                     @Value("${ras.passport.issuer}") String rasPassportIssuer,
+                                    @Value("${ras.enforce.ial2:false}") boolean enforceIal2,
                                     RoleService roleService,
                                     RASPassPortService rasPassPortService,
                                     RasPassportSignatureVerifier rasPassportSignatureVerifier,
@@ -67,6 +69,7 @@ public class RASAuthenticationService extends OktaAuthenticationService implemen
         this.rasPassPortService = rasPassPortService;
         this.rasPassportSignatureVerifier = rasPassportSignatureVerifier;
         this.rasPassportIssuer = rasPassportIssuer;
+        this.enforceIal2 = enforceIal2;
 
         logger.info("RASAuthenticationService is enabled: {}", isEnabled);
         logger.info("RASAuthenticationService initialized");
@@ -101,6 +104,13 @@ public class RASAuthenticationService extends OktaAuthenticationService implemen
 
         if (introspectResponse == null) {
             logger.info("LOGIN FAILED ___ USER NOT AUTHENTICATED ___ INTROSPECTION RESPONSE {} ___ CODE {}", introspectResponse, authRequest.get("code"));
+            return null;
+        }
+
+        // Enforce IAL2/AAL2 for RAS logins when configured. Opt-in via ras.enforce.ial2 because
+        // IAL1-only IdPs (eRA Commons, Google) cannot meet IAL2 and would otherwise be locked out.
+        if (this.enforceIal2 && !validateAssuranceLevels(introspectResponse)) {
+            logger.info("LOGIN FAILED ___ ASSURANCE LEVEL BELOW REQUIRED IAL2/AAL2 ___ CODE {}", authRequest.get("code"));
             return null;
         }
 
@@ -162,7 +172,63 @@ public class RASAuthenticationService extends OktaAuthenticationService implemen
                     user.getSubject(), this.rasPassportIssuer, rasPassport.get().getIss(), authRequest.get("code"));
             return Optional.empty();
         }
+
+        // Defense in depth: each embedded GA4GH visa is independently RAS-signed. Verify every visa,
+        // not just the outer passport, so a tampered visa cannot grant dbGaP permissions.
+        List<String> visas = rasPassport.get().getGa4ghPassportV1();
+        if (visas != null) {
+            for (String visa : visas) {
+                if (!this.rasPassportSignatureVerifier.isSignatureValid(visa)) {
+                    logger.error("validateRASPassport() LOGIN FAILED ___ VISA SIGNATURE INVALID ___ USER: {} ___ CODE {}",
+                            user.getSubject(), authRequest.get("code"));
+                    return Optional.empty();
+                }
+            }
+        }
         return rasPassport;
+    }
+
+    /**
+     * Verify the authentication (AAL) and identity (IAL) assurance levels carried in the {@code acr}
+     * claim meet the minimum required to access controlled-access (CADR) data: AAL >= 2 and IAL >= 2.
+     * Only consulted for RAS logins when {@code ras.enforce.ial2} is enabled.
+     */
+    protected boolean validateAssuranceLevels(JsonNode introspectResponse) {
+        JsonNode acrNode = introspectResponse.get("acr");
+        if (acrNode == null || StringUtils.isBlank(acrNode.asText())) {
+            logger.error("validateAssuranceLevels() no acr claim present in introspection response");
+            return false;
+        }
+
+        String acr = acrNode.asText();
+        int aal = parseAssuranceLevel(acr, "aal");
+        int ial = parseAssuranceLevel(acr, "ial");
+        return aal >= 2 && ial >= 2;
+    }
+
+    /**
+     * Parse the numeric level out of an {@code acr} value for a given assurance type. The {@code acr}
+     * claim is a space-delimited list of URIs such as
+     * {@code https://stsstg.nih.gov/assurance/aal/2 https://stsstg.nih.gov/assurance/ial/2}.
+     *
+     * @return the highest level found for the type, or 0 if none is present.
+     */
+    private int parseAssuranceLevel(String acr, String type) {
+        String marker = "/assurance/" + type + "/";
+        int highest = 0;
+        for (String token : acr.split("\\s+")) {
+            int idx = token.indexOf(marker);
+            if (idx < 0) {
+                continue;
+            }
+            try {
+                int level = Integer.parseInt(token.substring(idx + marker.length()).trim());
+                highest = Math.max(highest, level);
+            } catch (NumberFormatException e) {
+                logger.error("parseAssuranceLevel() could not parse {} level from acr token {}", type, token);
+            }
+        }
+        return highest;
     }
 
     protected User updateRasUserRoles(String code, User user, Passport rasPassport) {

--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/authentication/RASAuthenticationService.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/authentication/RASAuthenticationService.java
@@ -155,9 +155,11 @@ public class RASAuthenticationService extends OktaAuthenticationService implemen
             return Optional.empty();
         }
 
-        Optional<Passport> rasPassport = this.rasPassPortService.extractPassport(introspectResponse);
+        // Parse the exact token we just verified (verify-before-trust), rather than re-extracting it
+        // from the introspection response a second time.
+        Optional<Passport> rasPassport = JWTUtil.parsePassportJWTV11(passportNode.asText());
         if (rasPassport.isEmpty()) {
-            logger.info("LOGIN FAILED ___ NO RAS PASSPORT FOUND ___ USER: {} ___ CODE {}", user.getSubject(), authRequest.get("code"));
+            logger.error("validateRASPassport() LOGIN FAILED ___ PASSPORT COULD NOT BE PARSED ___ USER: {} ___ CODE {}", user.getSubject(), authRequest.get("code"));
             return Optional.empty();
         }
 
@@ -175,14 +177,11 @@ public class RASAuthenticationService extends OktaAuthenticationService implemen
 
         // Defense in depth: each embedded GA4GH visa is independently RAS-signed. Verify every visa,
         // not just the outer passport, so a tampered visa cannot grant dbGaP permissions.
-        List<String> visas = rasPassport.get().getGa4ghPassportV1();
-        if (visas != null) {
-            for (String visa : visas) {
-                if (!this.rasPassportSignatureVerifier.isSignatureValid(visa)) {
-                    logger.error("validateRASPassport() LOGIN FAILED ___ VISA SIGNATURE INVALID ___ USER: {} ___ CODE {}",
-                            user.getSubject(), authRequest.get("code"));
-                    return Optional.empty();
-                }
+        for (String visa : rasPassport.get().getGa4ghPassportV1()) {
+            if (!this.rasPassportSignatureVerifier.isSignatureValid(visa)) {
+                logger.error("validateRASPassport() LOGIN FAILED ___ VISA SIGNATURE INVALID ___ USER: {} ___ CODE {}",
+                        user.getSubject(), authRequest.get("code"));
+                return Optional.empty();
             }
         }
         return rasPassport;

--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/authentication/RASAuthenticationService.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/authentication/RASAuthenticationService.java
@@ -32,6 +32,7 @@ public class RASAuthenticationService extends OktaAuthenticationService implemen
     private final boolean isEnabled;
     private final RoleService roleService;
     private final RASPassPortService rasPassPortService;
+    private final RasPassportSignatureVerifier rasPassportSignatureVerifier;
     private final CacheEvictionService cacheEvictionService;
     private Connection rasConnection;
     private final String rasPassportIssuer;
@@ -56,6 +57,7 @@ public class RASAuthenticationService extends OktaAuthenticationService implemen
                                     @Value("${ras.passport.issuer}") String rasPassportIssuer,
                                     RoleService roleService,
                                     RASPassPortService rasPassPortService,
+                                    RasPassportSignatureVerifier rasPassportSignatureVerifier,
                                     ConnectionWebService connectionService, CacheEvictionService cacheEvictionService) {
         super(idp_provider_uri, clientId, clientSecret, restClientUtil);
 
@@ -63,6 +65,7 @@ public class RASAuthenticationService extends OktaAuthenticationService implemen
         this.isEnabled = isEnabled;
         this.roleService = roleService;
         this.rasPassPortService = rasPassPortService;
+        this.rasPassportSignatureVerifier = rasPassportSignatureVerifier;
         this.rasPassportIssuer = rasPassportIssuer;
 
         logger.info("RASAuthenticationService is enabled: {}", isEnabled);
@@ -127,6 +130,21 @@ public class RASAuthenticationService extends OktaAuthenticationService implemen
     }
 
     private Optional<Passport> extractAndVerifyPassport(Map<String, String> authRequest, JsonNode introspectResponse, User user) {
+        JsonNode passportNode = introspectResponse.get("passport_jwt_v11");
+        if (passportNode == null) {
+            logger.info("LOGIN FAILED ___ NO RAS PASSPORT FOUND ___ USER: {} ___ CODE {}", user.getSubject(), authRequest.get("code"));
+            return Optional.empty();
+        }
+
+        // Cryptographically verify RAS's signature on the passport JWT BEFORE trusting any claim it
+        // carries. Okta brokers this connection, so this signature is the only guarantee the dbGaP
+        // permissions were issued by RAS and not tampered with in transit. Fail closed.
+        if (!this.rasPassportSignatureVerifier.isSignatureValid(passportNode.asText())) {
+            logger.error("validateRASPassport() LOGIN FAILED ___ PASSPORT SIGNATURE INVALID ___ USER: {} ___ CODE {}",
+                    user.getSubject(), authRequest.get("code"));
+            return Optional.empty();
+        }
+
         Optional<Passport> rasPassport = this.rasPassPortService.extractPassport(introspectResponse);
         if (rasPassport.isEmpty()) {
             logger.info("LOGIN FAILED ___ NO RAS PASSPORT FOUND ___ USER: {} ___ CODE {}", user.getSubject(), authRequest.get("code"));

--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/authentication/RASAuthenticationService.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/authentication/RASAuthenticationService.java
@@ -190,8 +190,9 @@ public class RASAuthenticationService extends OktaAuthenticationService implemen
 
     /**
      * Verify the authentication (AAL) and identity (IAL) assurance levels carried in the {@code acr}
-     * claim meet the minimum required to access controlled-access (CADR) data: AAL >= 2 and IAL >= 2.
-     * Only consulted for RAS logins when {@code ras.enforce.ial2} is enabled.
+     * claim meet the minimum required to access controlled-access (CADR) data. Per the NIH RAS rule
+     * this is AAL >= 2 AND (IAL >= 2 OR InCommon IAP = high). Only consulted for RAS logins when
+     * {@code ras.enforce.ial2} is enabled.
      */
     protected boolean validateAssuranceLevels(JsonNode introspectResponse) {
         JsonNode acrNode = introspectResponse.get("acr");
@@ -203,7 +204,20 @@ public class RASAuthenticationService extends OktaAuthenticationService implemen
         String acr = acrNode.asText();
         int aal = parseAssuranceLevel(acr, "aal");
         int ial = parseAssuranceLevel(acr, "ial");
-        return aal >= 2 && ial >= 2;
+        return aal >= 2 && (ial >= 2 || hasInCommonIapHigh(acr));
+    }
+
+    /**
+     * InCommon federation IdPs express identity proofing via an Identity Assurance Profile rather than
+     * a numeric IAL; IAP "high" is CADR-eligible.
+     */
+    private boolean hasInCommonIapHigh(String acr) {
+        for (String token : acr.split("\\s+")) {
+            if (token.endsWith("/assurance/iap/high")) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**

--- a/pic-sure-auth-services/src/main/resources/application.properties
+++ b/pic-sure-auth-services/src/main/resources/application.properties
@@ -117,6 +117,8 @@ ras.okta.client.id=${RAS_OKTA_CLIENT_ID:false}
 ras.okta.client.secret=${RAS_OKTA_CLIENT_SECRET:false}
 ras.idp.uri=${RAS_IDP_URI:false}
 ras.passport.issuer=${RAS_PASSPORT_ISSUER:false}
+# Enforce IAL2/AAL2 (acr) for RAS logins. Opt-in: enabling blocks IAL1-only IdPs (eRA Commons, Google).
+ras.enforce.ial2=${RAS_ENFORCE_IAL2:false}
 
 server.servlet.session.cookie.http-only=true
 server.servlet.session.cookie.secure=true

--- a/pic-sure-auth-services/src/test/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/RASPassPortServiceTest.java
+++ b/pic-sure-auth-services/src/test/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/RASPassPortServiceTest.java
@@ -64,6 +64,28 @@ public class RASPassPortServiceTest {
             + ".fakesignature";
 
     @Test
+    public void testIsExpired_passportPastExpirationIsExpiredRegardlessOfIssuedAt() {
+        long now = System.currentTimeMillis() / 1000;
+        Passport passport = new Passport();
+        passport.setExp(now - 100_000); // already expired
+        passport.setIat(now + 100_000); // malformed / future issued-at must not mask expiry
+
+        assertTrue(rasPassPortService.isExpired(passport),
+                "A passport past its exp must be reported expired even when iat is not in the past");
+    }
+
+    @Test
+    public void testIsExpired_validPassportIsNotExpired() {
+        long now = System.currentTimeMillis() / 1000;
+        Passport passport = new Passport();
+        passport.setExp(now + 100_000); // not yet expired
+        passport.setIat(now - 100_000);
+
+        assertFalse(rasPassPortService.isExpired(passport),
+                "A passport whose exp is in the future must not be reported expired");
+    }
+
+    @Test
     public void testGa4ghPassPortStudies_IsNull() {
         Set<RasDbgapPermission> permissions = rasPassPortService.ga4ghPassportToRasDbgapPermissions(null);
         assertNull(permissions);

--- a/pic-sure-auth-services/src/test/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/RASPassPortServiceTest.java
+++ b/pic-sure-auth-services/src/test/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/RASPassPortServiceTest.java
@@ -141,6 +141,35 @@ public class RASPassPortServiceTest {
     }
 
     @Test
+    public void testParsePassport_absentGa4ghPassportV1_isEmptyNotNull() {
+        long future = (System.currentTimeMillis() / 1000) + 100_000;
+        String payload = "{\"iss\":\"https://stsstg.nih.gov\",\"exp\":" + future + "}";
+        Optional<Passport> parsed = JWTUtil.parsePassportJWTV11(standardB64Jwt(payload));
+
+        assertTrue(parsed.isPresent());
+        assertNotNull(parsed.get().getGa4ghPassportV1(), "missing ga4gh_passport_v1 must yield an empty list, not null");
+        assertTrue(parsed.get().getGa4ghPassportV1().isEmpty());
+    }
+
+    @Test
+    public void testValidateUserPassport_passportWithNoVisas_skipsWithoutNpe() {
+        long future = (System.currentTimeMillis() / 1000) + 100_000;
+        String payload = "{\"iss\":\"https://stsstg.nih.gov\",\"exp\":" + future + ",\"iat\":" + (future - 200_000) + "}";
+        String passport = standardB64Jwt(payload);
+
+        RASPassPortService svc = spy(new RASPassPortService(restClientUtil, userService, "https://test.com/", cacheEvictionService, null));
+        User user = new User();
+        user.setSubject("test-subject");
+        user.setPassport(passport);
+
+        RASPassPortService.ValidationOutcome outcome = svc.validateUserPassport(user);
+
+        assertEquals(RASPassPortService.ValidationOutcome.SKIPPED, outcome,
+                "A passport with no ga4gh_passport_v1 visas must skip cleanly, not NPE");
+        verify(svc, never()).validateVisa(any());
+    }
+
+    @Test
     public void testIsExpired_passportPastExpirationIsExpiredRegardlessOfIssuedAt() {
         long now = System.currentTimeMillis() / 1000;
         Passport passport = new Passport();

--- a/pic-sure-auth-services/src/test/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/RASPassPortServiceTest.java
+++ b/pic-sure-auth-services/src/test/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/RASPassPortServiceTest.java
@@ -141,6 +141,36 @@ public class RASPassPortServiceTest {
     }
 
     @Test
+    public void testValidateVisa_transportError_returnsEmpty() {
+        when(restClientUtil.retrievePostResponse(any(String.class), any()))
+                .thenThrow(new RuntimeException("connection refused"));
+
+        Optional<String> response = rasPassPortService.validateVisa(visa);
+
+        assertTrue(response.isEmpty(),
+                "A transport error must return empty (skip), not a 'Visa Expired' verdict that logs the user out");
+    }
+
+    @Test
+    public void testValidateUserPassport_transientRasError_doesNotLogOut() {
+        long future = (System.currentTimeMillis() / 1000) + 100_000;
+        String passport = passportJwt(future, visaJwt(future, "visa-one"));
+        when(restClientUtil.retrievePostResponse(any(String.class), any()))
+                .thenThrow(new RuntimeException("RAS unreachable"));
+
+        RASPassPortService svc = new RASPassPortService(restClientUtil, userService, "https://test.com/", cacheEvictionService, null);
+        User user = new User();
+        user.setSubject("test-subject");
+        user.setPassport(passport);
+
+        RASPassPortService.ValidationOutcome outcome = svc.validateUserPassport(user);
+
+        assertEquals(RASPassPortService.ValidationOutcome.SKIPPED, outcome,
+                "A transient RAS validation error must not invalidate the passport");
+        verify(userService, never()).logoutUser(any());
+    }
+
+    @Test
     public void testParsePassport_absentGa4ghPassportV1_isEmptyNotNull() {
         long future = (System.currentTimeMillis() / 1000) + 100_000;
         String payload = "{\"iss\":\"https://stsstg.nih.gov\",\"exp\":" + future + "}";

--- a/pic-sure-auth-services/src/test/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/RASPassPortServiceTest.java
+++ b/pic-sure-auth-services/src/test/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/RASPassPortServiceTest.java
@@ -1,6 +1,7 @@
 package edu.harvard.hms.dbmi.avillach.auth.service.impl;
 
 import edu.harvard.dbmi.avillach.logging.LoggingClient;
+import edu.harvard.hms.dbmi.avillach.auth.entity.User;
 import edu.harvard.hms.dbmi.avillach.auth.enums.PassportValidationResponse;
 import edu.harvard.hms.dbmi.avillach.auth.model.ras.Ga4ghPassportV1;
 import edu.harvard.hms.dbmi.avillach.auth.model.ras.Passport;
@@ -15,6 +16,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.ContextConfiguration;
 
+import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -22,7 +24,7 @@ import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 @SpringBootTest
 @ContextConfiguration(classes = {RASPassPortService.class})
@@ -62,6 +64,81 @@ public class RASPassPortServiceTest {
     private static final String multiVisaPassportWithEmptyPermissions = "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6InRlc3Qta2V5In0"
             + ".eyJzdWIiOiJ0ZXN0LXN1Yi0wMDEiLCJqdGkiOiJwYXNzcG9ydC1qdGktMDAyIiwic2NvcGUiOiJvcGVuaWQgZ2E0Z2hfcGFzc3BvcnRfdjEiLCJ0eG4iOiJ0ZXN0LXR4bi0wMDEiLCJpc3MiOiJodHRwczovL3N0c3N0Zy5uaWguZ292IiwiaWF0IjoxNjIwMjEwMzYyLCJleHAiOjE2MjAyNTM1NjIsImdhNGdoX3Bhc3Nwb3J0X3YxIjpbImV5SjBlWEFpT2lKS1YxUWlMQ0poYkdjaU9pSlNVekkxTmlJc0ltdHBaQ0k2SW5SbGMzUXRhMlY1SW4wLmV5SnBjM01pT2lKb2RIUndjem92TDNOMGMzTjBaeTV1YVdndVoyOTJJaXdpYzNWaUlqb2lkR1Z6ZEMxemRXSXRNREF4SWl3aWFXRjBJam94TmpJd01qRXdNell5TENKbGVIQWlPakUyTWpBeU5UTTFOaklzSW5OamIzQmxJam9pYjNCbGJtbGtJR2RoTkdkb1gzQmhjM053YjNKMFgzWXhJaXdpYW5ScElqb2lkbWx6WVMxcWRHa3RiR2x1YTJWa0xUQXdNU0lzSW5SNGJpSTZJblJsYzNRdGRIaHVMVEF3TVNJc0ltZGhOR2RvWDNacGMyRmZkakVpT25zaWRIbHdaU0k2SWt4cGJtdGxaRWxrWlc1MGFYUnBaWE1pTENKaGMzTmxjblJsWkNJNk1UWXlNREl4TURNMk1pd2lkbUZzZFdVaU9pSjBaWE4wTFd4cGJtdGxaQzFwWkMxMllXeDFaU0lzSW5OdmRYSmpaU0k2SW1oMGRIQnpPaTh2YzNSemMzUm5MbTVwYUM1bmIzWWlMQ0ppZVNJNkltNXBhQzVuYjNZaWZYMC5mYWtlc2lnbmF0dXJlIiwiZXlKMGVYQWlPaUpLVjFRaUxDSmhiR2NpT2lKU1V6STFOaUlzSW10cFpDSTZJblJsYzNRdGEyVjVJbjAuZXlKcGMzTWlPaUpvZEhSd2N6b3ZMM04wYzNOMFp5NXVhV2d1WjI5Mklpd2ljM1ZpSWpvaWRHVnpkQzF6ZFdJdE1EQXhJaXdpYVdGMElqb3hOakl3TWpFd016WXlMQ0psZUhBaU9qRTJNakF5TlRNMU5qSXNJbk5qYjNCbElqb2liM0JsYm1sa0lHZGhOR2RvWDNCaGMzTndiM0owWDNZeElpd2lhblJwSWpvaWRtbHpZUzFxZEdrdFpHSm5ZWEF0Wlcxd2RIa3RNREF4SWl3aWRIaHVJam9pZEdWemRDMTBlRzR0TURBeElpd2laMkUwWjJoZmRtbHpZVjkyTVNJNmV5SjBlWEJsSWpvaWFIUjBjSE02THk5eVlYTXVibWxvTG1kdmRpOTJhWE5oY3k5Mk1TNHhJaXdpWVhOelpYSjBaV1FpT2pFMk1qQXlNVEF6TmpJc0luWmhiSFZsSWpvaWFIUjBjSE02THk5emRITnpkR2N1Ym1sb0xtZHZkaTl3WVhOemNHOXlkQzlrWW1kaGNDOTJNUzR4SWl3aWMyOTFjbU5sSWpvaWFIUjBjSE02THk5dVkySnBMbTVzYlM1dWFXZ3VaMjkyTDJkaGNDSXNJbUo1SWpvaVpHRmpJbjBzSW5KaGMxOWtZbWRoY0Y5d1pYSnRhWE56YVc5dWN5STZXMTE5LmZha2VzaWduYXR1cmUiXX0"
             + ".fakesignature";
+
+    @Test
+    public void testValidateUserPassport_invalidatesWhenAnyVisaIsInvalid() {
+        long future = (System.currentTimeMillis() / 1000) + 100_000;
+        String visa1 = visaJwt(future, "visa-one");
+        String visa2 = visaJwt(future, "visa-two");
+        assertNotEquals(visa1, visa2, "test visas must be distinct so per-visa stubbing is meaningful");
+        String passport = passportJwt(future, visa1, visa2);
+
+        RASPassPortService svc = spy(new RASPassPortService(restClientUtil, userService, "https://test.com/", cacheEvictionService, null));
+        // First visa validates, second does not. The whole passport must be invalidated.
+        doReturn(Optional.of(PassportValidationResponse.VALID.getValue())).when(svc).validateVisa(visa1);
+        doReturn(Optional.of(PassportValidationResponse.INVALID.getValue())).when(svc).validateVisa(visa2);
+
+        User user = new User();
+        user.setSubject("test-subject");
+        user.setPassport(passport);
+
+        RASPassPortService.ValidationOutcome outcome = svc.validateUserPassport(user);
+
+        assertEquals(RASPassPortService.ValidationOutcome.INVALIDATED, outcome,
+                "A passport with any invalid visa must be invalidated, not validated after the first visa");
+        verify(svc).validateVisa(visa2);
+    }
+
+    @Test
+    public void testValidateUserPassport_validatesEveryVisaWhenAllValid() {
+        long future = (System.currentTimeMillis() / 1000) + 100_000;
+        String visa1 = visaJwt(future, "visa-one");
+        String visa2 = visaJwt(future, "visa-two");
+        String passport = passportJwt(future, visa1, visa2);
+
+        RASPassPortService svc = spy(new RASPassPortService(restClientUtil, userService, "https://test.com/", cacheEvictionService, null));
+        doReturn(Optional.of(PassportValidationResponse.VALID.getValue())).when(svc).validateVisa(visa1);
+        doReturn(Optional.of(PassportValidationResponse.VALID.getValue())).when(svc).validateVisa(visa2);
+
+        User user = new User();
+        user.setSubject("test-subject");
+        user.setPassport(passport);
+
+        RASPassPortService.ValidationOutcome outcome = svc.validateUserPassport(user);
+
+        assertEquals(RASPassPortService.ValidationOutcome.VALIDATED, outcome);
+        // Every visa must be validated, not just the first.
+        verify(svc).validateVisa(visa1);
+        verify(svc).validateVisa(visa2);
+    }
+
+    private static String visaJwt(long exp, String id) {
+        String payload = "{\"iss\":\"https://stsstg.nih.gov\",\"exp\":" + exp + ",\"jti\":\"" + id + "\","
+                + "\"ga4gh_visa_v1\":{\"type\":\"https://ras.nih.gov/visas/v1.1\",\"value\":\"v\",\"source\":\"s\",\"by\":\"dac\"}}";
+        return standardB64Jwt(payload);
+    }
+
+    private static String passportJwt(long exp, String... visas) {
+        StringBuilder arr = new StringBuilder("[");
+        for (int i = 0; i < visas.length; i++) {
+            if (i > 0) arr.append(",");
+            arr.append("\"").append(visas[i]).append("\"");
+        }
+        arr.append("]");
+        String payload = "{\"iss\":\"https://stsstg.nih.gov\",\"exp\":" + exp + ",\"iat\":" + (exp - 200_000)
+                + ",\"ga4gh_passport_v1\":" + arr + "}";
+        return standardB64Jwt(payload);
+    }
+
+    // Build header.payload.signature using STANDARD base64, matching the decoder JWTUtil uses to parse.
+    private static String standardB64Jwt(String payloadJson) {
+        String header = b64("{\"alg\":\"RS256\",\"kid\":\"k\"}");
+        return header + "." + b64(payloadJson) + ".signature";
+    }
+
+    private static String b64(String s) {
+        return Base64.getEncoder().encodeToString(s.getBytes(StandardCharsets.UTF_8));
+    }
 
     @Test
     public void testIsExpired_passportPastExpirationIsExpiredRegardlessOfIssuedAt() {

--- a/pic-sure-auth-services/src/test/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/RasPassportSignatureVerifierTest.java
+++ b/pic-sure-auth-services/src/test/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/RasPassportSignatureVerifierTest.java
@@ -11,7 +11,9 @@ import java.security.PrivateKey;
 import java.security.interfaces.RSAPublicKey;
 import java.util.Base64;
 import java.util.Date;
+import java.util.concurrent.atomic.AtomicLong;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -107,7 +109,89 @@ public class RasPassportSignatureVerifierTest {
                 "A passport with a forged signature segment must be rejected");
     }
 
+    @Test
+    public void rejectsNonRs256SignedToken() {
+        // Same key + kid, but signed with RS384. Verification must accept only RS256.
+        String rs384 = Jwts.builder()
+                .header().keyId(KID).and()
+                .subject("test-sub").issuer(ISSUER)
+                .issuedAt(new Date()).expiration(new Date(System.currentTimeMillis() + 3_600_000))
+                .signWith(rasKeyPair.getPrivate(), Jwts.SIG.RS384)
+                .compact();
+
+        assertFalse(verifier.isSignatureValid(rs384), "Only RS256-signed passports may be accepted");
+    }
+
+    @Test
+    public void rejectsTokenWithNoKid() {
+        String noKid = Jwts.builder()
+                .subject("test-sub").issuer(ISSUER)
+                .issuedAt(new Date()).expiration(new Date(System.currentTimeMillis() + 3_600_000))
+                .signWith(rasKeyPair.getPrivate(), Jwts.SIG.RS256)
+                .compact();
+
+        assertFalse(verifier.isSignatureValid(noKid), "A token without a kid header must be rejected");
+    }
+
+    @Test
+    public void rejectsWhenJwksFetchReturnsNon2xx() {
+        RasPassportSignatureVerifier.UrlFetcher fetcher = url -> {
+            if ((ISSUER + "/.well-known/openid-configuration").equals(url)) {
+                return new RasPassportSignatureVerifier.FetchResult(200, "HTTP_2", null, "{\"jwks_uri\":\"" + JWKS_URI + "\"}");
+            }
+            return new RasPassportSignatureVerifier.FetchResult(503, "HTTP_2", null, "{\"error\":\"unavailable\"}");
+        };
+        RasPassportSignatureVerifier v = new RasPassportSignatureVerifier(ISSUER, fetcher);
+
+        assertFalse(v.isSignatureValid(signedJwt(KID, rasKeyPair.getPrivate(), "test-sub")),
+                "A non-2xx JWKS response must fail closed");
+    }
+
+    @Test
+    public void doesNotRefetchJwksForRepeatedUnknownKid() {
+        int[] jwksFetches = {0};
+        RasPassportSignatureVerifier v = new RasPassportSignatureVerifier(ISSUER, countingFetcher(jwksFetches));
+        // kid absent from the JWKS (e.g. rotated-out or forged).
+        String unknownKid = signedJwt("rotated-out-kid", rasKeyPair.getPrivate(), "test-sub");
+
+        assertFalse(v.isSignatureValid(unknownKid));
+        assertFalse(v.isSignatureValid(unknownKid));
+
+        assertEquals(1, jwksFetches[0],
+                "Repeated verifications of an unknown kid must not refetch the JWKS each time (throttled)");
+    }
+
+    @Test
+    public void refetchesJwksAfterTtl() {
+        int[] jwksFetches = {0};
+        AtomicLong clock = new AtomicLong(1_000_000L);
+        RasPassportSignatureVerifier v = new RasPassportSignatureVerifier(ISSUER, countingFetcher(jwksFetches), clock::get);
+        String valid = signedJwt(KID, rasKeyPair.getPrivate(), "test-sub");
+
+        assertTrue(v.isSignatureValid(valid));
+        assertTrue(v.isSignatureValid(valid));
+        assertEquals(1, jwksFetches[0], "A cached key must be reused within the TTL");
+
+        clock.addAndGet(RasPassportSignatureVerifier.CACHE_TTL_MS + 1);
+        assertTrue(v.isSignatureValid(valid));
+        assertEquals(2, jwksFetches[0], "After the TTL the JWKS must be re-pulled so rotated-out keys are dropped");
+    }
+
     // ---- helpers ----
+
+    private RasPassportSignatureVerifier.UrlFetcher countingFetcher(int[] jwksFetches) {
+        String jwks = buildJwksJson(KID, (RSAPublicKey) rasKeyPair.getPublic());
+        return url -> {
+            if ((ISSUER + "/.well-known/openid-configuration").equals(url)) {
+                return new RasPassportSignatureVerifier.FetchResult(200, "HTTP_2", null, "{\"jwks_uri\":\"" + JWKS_URI + "\"}");
+            }
+            if (JWKS_URI.equals(url)) {
+                jwksFetches[0]++;
+                return new RasPassportSignatureVerifier.FetchResult(200, "HTTP_2", null, jwks);
+            }
+            throw new IllegalArgumentException("unexpected url: " + url);
+        };
+    }
 
     private static String signedJwt(String kid, PrivateKey signingKey, String subject) {
         return Jwts.builder()

--- a/pic-sure-auth-services/src/test/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/RasPassportSignatureVerifierTest.java
+++ b/pic-sure-auth-services/src/test/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/RasPassportSignatureVerifierTest.java
@@ -1,0 +1,126 @@
+package edu.harvard.hms.dbmi.avillach.auth.service.impl;
+
+import edu.harvard.hms.dbmi.avillach.auth.utils.RestClientUtil;
+import io.jsonwebtoken.Jwts;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.ResponseEntity;
+
+import java.math.BigInteger;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.PrivateKey;
+import java.security.interfaces.RSAPublicKey;
+import java.util.Base64;
+import java.util.Date;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Verifies that {@link RasPassportSignatureVerifier} cryptographically validates the RS256
+ * signature of a RAS passport JWT against RAS's published JWKS, fetched via OIDC discovery.
+ */
+public class RasPassportSignatureVerifierTest {
+
+    private static final String ISSUER = "https://stsstg.nih.gov";
+    private static final String JWKS_URI = "https://stsstg.nih.gov/jwks";
+    private static final String KID = "ras-test-key";
+
+    private RestClientUtil restClientUtil;
+    private KeyPair rasKeyPair;
+    private KeyPair attackerKeyPair;
+    private RasPassportSignatureVerifier verifier;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        restClientUtil = mock(RestClientUtil.class);
+        rasKeyPair = generateKeyPair();
+        attackerKeyPair = generateKeyPair();
+
+        when(restClientUtil.retrieveGetResponse(eq(ISSUER + "/.well-known/openid-configuration"), any()))
+                .thenReturn(ResponseEntity.ok("{\"jwks_uri\":\"" + JWKS_URI + "\"}"));
+        when(restClientUtil.retrieveGetResponse(eq(JWKS_URI), any()))
+                .thenReturn(ResponseEntity.ok(buildJwksJson(KID, (RSAPublicKey) rasKeyPair.getPublic())));
+
+        verifier = new RasPassportSignatureVerifier(restClientUtil, ISSUER);
+    }
+
+    @Test
+    public void acceptsPassportSignedByPublishedKey() {
+        String passport = signedJwt(KID, rasKeyPair.getPrivate(), "test-sub");
+
+        assertTrue(verifier.isSignatureValid(passport),
+                "A passport signed by RAS's published JWKS key must be accepted");
+    }
+
+    @Test
+    public void rejectsPassportWithTamperedPayload() {
+        // Same key + kid, but the payload is swapped after signing, so the signature no longer matches.
+        String[] original = signedJwt(KID, rasKeyPair.getPrivate(), "real-sub").split("\\.");
+        String[] forged = signedJwt(KID, rasKeyPair.getPrivate(), "attacker-sub").split("\\.");
+        String tampered = forged[0] + "." + forged[1] + "." + original[2];
+
+        assertFalse(verifier.isSignatureValid(tampered),
+                "A passport whose payload was altered after signing must be rejected");
+    }
+
+    @Test
+    public void rejectsPassportSignedByUnknownKey() {
+        // Advertises the published kid, but is actually signed by a key RAS never published.
+        String passport = signedJwt(KID, attackerKeyPair.getPrivate(), "attacker-sub");
+
+        assertFalse(verifier.isSignatureValid(passport),
+                "A passport signed by a key absent from RAS's JWKS must be rejected");
+    }
+
+    @Test
+    public void rejectsPassportWithFakeSignature() {
+        String[] parts = signedJwt(KID, rasKeyPair.getPrivate(), "test-sub").split("\\.");
+        String fakeSigned = parts[0] + "." + parts[1] + ".fakesignature";
+
+        assertFalse(verifier.isSignatureValid(fakeSigned),
+                "A passport with a forged signature segment must be rejected");
+    }
+
+    // ---- helpers ----
+
+    private static String signedJwt(String kid, PrivateKey signingKey, String subject) {
+        return Jwts.builder()
+                .header().keyId(kid).and()
+                .subject(subject)
+                .issuer(ISSUER)
+                .issuedAt(new Date())
+                .expiration(new Date(System.currentTimeMillis() + 3_600_000))
+                .signWith(signingKey, Jwts.SIG.RS256)
+                .compact();
+    }
+
+    private static KeyPair generateKeyPair() throws Exception {
+        KeyPairGenerator gen = KeyPairGenerator.getInstance("RSA");
+        gen.initialize(2048);
+        return gen.generateKeyPair();
+    }
+
+    private static String buildJwksJson(String kid, RSAPublicKey key) {
+        String n = base64Url(key.getModulus());
+        String e = base64Url(key.getPublicExponent());
+        return "{\"keys\":[{\"kty\":\"RSA\",\"alg\":\"RS256\",\"use\":\"sig\",\"kid\":\""
+                + kid + "\",\"n\":\"" + n + "\",\"e\":\"" + e + "\"}]}";
+    }
+
+    private static String base64Url(BigInteger value) {
+        byte[] bytes = value.toByteArray();
+        // Strip the sign byte BigInteger may prepend so the JWK encoding matches RFC 7518.
+        if (bytes.length > 1 && bytes[0] == 0) {
+            byte[] trimmed = new byte[bytes.length - 1];
+            System.arraycopy(bytes, 1, trimmed, 0, trimmed.length);
+            bytes = trimmed;
+        }
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
+    }
+}

--- a/pic-sure-auth-services/src/test/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/RasPassportSignatureVerifierTest.java
+++ b/pic-sure-auth-services/src/test/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/RasPassportSignatureVerifierTest.java
@@ -1,10 +1,8 @@
 package edu.harvard.hms.dbmi.avillach.auth.service.impl;
 
-import edu.harvard.hms.dbmi.avillach.auth.utils.RestClientUtil;
 import io.jsonwebtoken.Jwts;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.http.ResponseEntity;
 
 import java.math.BigInteger;
 import java.security.KeyPair;
@@ -16,14 +14,11 @@ import java.util.Date;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 /**
  * Verifies that {@link RasPassportSignatureVerifier} cryptographically validates the RS256
  * signature of a RAS passport JWT against RAS's published JWKS, fetched via OIDC discovery.
+ * The HTTP layer is replaced with a canned fetcher so the tests exercise real RSA verification.
  */
 public class RasPassportSignatureVerifierTest {
 
@@ -31,23 +26,28 @@ public class RasPassportSignatureVerifierTest {
     private static final String JWKS_URI = "https://stsstg.nih.gov/jwks";
     private static final String KID = "ras-test-key";
 
-    private RestClientUtil restClientUtil;
     private KeyPair rasKeyPair;
     private KeyPair attackerKeyPair;
     private RasPassportSignatureVerifier verifier;
 
     @BeforeEach
     public void setUp() throws Exception {
-        restClientUtil = mock(RestClientUtil.class);
         rasKeyPair = generateKeyPair();
         attackerKeyPair = generateKeyPair();
 
-        when(restClientUtil.retrieveGetResponse(eq(ISSUER + "/.well-known/openid-configuration"), any()))
-                .thenReturn(ResponseEntity.ok("{\"jwks_uri\":\"" + JWKS_URI + "\"}"));
-        when(restClientUtil.retrieveGetResponse(eq(JWKS_URI), any()))
-                .thenReturn(ResponseEntity.ok(buildJwksJson(KID, (RSAPublicKey) rasKeyPair.getPublic())));
+        String jwks = buildJwksJson(KID, (RSAPublicKey) rasKeyPair.getPublic());
+        RasPassportSignatureVerifier.UrlFetcher fetcher = url -> {
+            if ((ISSUER + "/.well-known/openid-configuration").equals(url)) {
+                return new RasPassportSignatureVerifier.FetchResult(
+                        200, "HTTP_2", null, "{\"jwks_uri\":\"" + JWKS_URI + "\"}");
+            }
+            if (JWKS_URI.equals(url)) {
+                return new RasPassportSignatureVerifier.FetchResult(200, "HTTP_2", null, jwks);
+            }
+            throw new IllegalArgumentException("unexpected url: " + url);
+        };
 
-        verifier = new RasPassportSignatureVerifier(restClientUtil, ISSUER);
+        verifier = new RasPassportSignatureVerifier(ISSUER, fetcher);
     }
 
     @Test

--- a/pic-sure-auth-services/src/test/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/RasPassportSignatureVerifierTest.java
+++ b/pic-sure-auth-services/src/test/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/RasPassportSignatureVerifierTest.java
@@ -79,6 +79,26 @@ public class RasPassportSignatureVerifierTest {
     }
 
     @Test
+    public void rejectsWhenJwksBodyIsTruncated() {
+        // Reproduces the production incident: the JWKS body comes back truncated mid-stream, so no
+        // key can be loaded. Verification must fail closed rather than accept the passport.
+        String validPassport = signedJwt(KID, rasKeyPair.getPrivate(), "test-sub");
+        RasPassportSignatureVerifier.UrlFetcher truncating = url -> {
+            if ((ISSUER + "/.well-known/openid-configuration").equals(url)) {
+                return new RasPassportSignatureVerifier.FetchResult(
+                        200, "HTTP_1_1", "1998", "{\"jwks_uri\":\"" + JWKS_URI + "\"}");
+            }
+            // JWKS truncated mid-field, exactly like the gateway-over-HTTP/1.1 failure.
+            return new RasPassportSignatureVerifier.FetchResult(
+                    200, "HTTP_1_1", "1998", "{\"keys\":[{\"kty\":\"RSA\",\"kid\":\"" + KID + "\",\"n");
+        };
+        RasPassportSignatureVerifier truncatedVerifier = new RasPassportSignatureVerifier(ISSUER, truncating);
+
+        assertFalse(truncatedVerifier.isSignatureValid(validPassport),
+                "A truncated/unparseable JWKS must cause verification to fail closed");
+    }
+
+    @Test
     public void rejectsPassportWithFakeSignature() {
         String[] parts = signedJwt(KID, rasKeyPair.getPrivate(), "test-sub").split("\\.");
         String fakeSigned = parts[0] + "." + parts[1] + ".fakesignature";

--- a/pic-sure-auth-services/src/test/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/authentication/RASAuthenticationServiceTest.java
+++ b/pic-sure-auth-services/src/test/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/authentication/RASAuthenticationServiceTest.java
@@ -173,6 +173,25 @@ public class RASAuthenticationServiceTest {
         assertFalse(rasAuthenticationService.validateAssuranceLevels(node));
     }
 
+    @Test
+    public void testValidateAssuranceLevels_aal2IapHigh_passes() throws Exception {
+        // InCommon federation: AAL2 + IAP high is CADR-eligible even without an ial/2 token.
+        JsonNode node = acrNode("https://stsstg.nih.gov/assurance/aal/2 https://stsstg.nih.gov/assurance/iap/high");
+        assertTrue(rasAuthenticationService.validateAssuranceLevels(node));
+    }
+
+    @Test
+    public void testValidateAssuranceLevels_aal1IapHigh_fails() throws Exception {
+        JsonNode node = acrNode("https://stsstg.nih.gov/assurance/aal/1 https://stsstg.nih.gov/assurance/iap/high");
+        assertFalse(rasAuthenticationService.validateAssuranceLevels(node));
+    }
+
+    @Test
+    public void testValidateAssuranceLevels_aal2IapMedium_fails() throws Exception {
+        JsonNode node = acrNode("https://stsstg.nih.gov/assurance/aal/2 https://stsstg.nih.gov/assurance/iap/medium");
+        assertFalse(rasAuthenticationService.validateAssuranceLevels(node));
+    }
+
     private JsonNode acrNode(String acr) throws Exception {
         return new ObjectMapper().readTree("{\"acr\":\"" + acr + "\"}");
     }

--- a/pic-sure-auth-services/src/test/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/authentication/RASAuthenticationServiceTest.java
+++ b/pic-sure-auth-services/src/test/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/authentication/RASAuthenticationServiceTest.java
@@ -13,6 +13,7 @@ import edu.harvard.hms.dbmi.avillach.auth.model.ras.Passport;
 import edu.harvard.hms.dbmi.avillach.auth.model.ras.RasDbgapPermission;
 import edu.harvard.hms.dbmi.avillach.auth.repository.RoleRepository;
 import edu.harvard.hms.dbmi.avillach.auth.repository.UserRepository;
+import edu.harvard.hms.dbmi.avillach.auth.utils.JWTUtil;
 import edu.harvard.hms.dbmi.avillach.auth.service.impl.*;
 import edu.harvard.hms.dbmi.avillach.auth.utils.FenceMappingUtility;
 import edu.harvard.hms.dbmi.avillach.auth.utils.RestClientUtil;
@@ -83,6 +84,7 @@ public class RASAuthenticationServiceTest {
                 "",
                 "",
                 "https://stsstg.nih.gov",
+                false,
                 roleService,
                 rasPassPortService,
                 rasPassportSignatureVerifier,
@@ -142,6 +144,80 @@ public class RASAuthenticationServiceTest {
     }
 
     @Test
+    public void testValidateAssuranceLevels_aal2ial2_passes() throws Exception {
+        JsonNode node = acrNode("https://stsstg.nih.gov/assurance/aal/2 https://stsstg.nih.gov/assurance/ial/2");
+        assertTrue(rasAuthenticationService.validateAssuranceLevels(node));
+    }
+
+    @Test
+    public void testValidateAssuranceLevels_aal3ial2_passes() throws Exception {
+        JsonNode node = acrNode("https://stsstg.nih.gov/assurance/aal/3 https://stsstg.nih.gov/assurance/ial/2");
+        assertTrue(rasAuthenticationService.validateAssuranceLevels(node));
+    }
+
+    @Test
+    public void testValidateAssuranceLevels_aal1ial1_fails() throws Exception {
+        JsonNode node = acrNode("https://stsstg.nih.gov/assurance/aal/1 https://stsstg.nih.gov/assurance/ial/1");
+        assertFalse(rasAuthenticationService.validateAssuranceLevels(node));
+    }
+
+    @Test
+    public void testValidateAssuranceLevels_aal2ial1_fails() throws Exception {
+        JsonNode node = acrNode("https://stsstg.nih.gov/assurance/aal/2 https://stsstg.nih.gov/assurance/ial/1");
+        assertFalse(rasAuthenticationService.validateAssuranceLevels(node));
+    }
+
+    @Test
+    public void testValidateAssuranceLevels_missingAcr_fails() throws Exception {
+        JsonNode node = new ObjectMapper().readTree("{\"sub\":\"x\"}");
+        assertFalse(rasAuthenticationService.validateAssuranceLevels(node));
+    }
+
+    private JsonNode acrNode(String acr) throws Exception {
+        return new ObjectMapper().readTree("{\"acr\":\"" + acr + "\"}");
+    }
+
+    @Test
+    public void testAuthenticate_rejectsWhenIal2EnforcedAndAssuranceTooLow() {
+        // A service with ras.enforce.ial2 = true must reject a login whose acr is below AAL2/IAL2,
+        // before any user record is created or role granted.
+        RASAuthenticationService enforcingService = new RASAuthenticationService(
+                userService, restClientUtil, true, "test.com", "", "", "",
+                "https://stsstg.nih.gov", true,
+                roleService, rasPassPortService, rasPassportSignatureVerifier,
+                connectionService, cacheEvictionService);
+        Connection rasConnection = new Connection();
+        rasConnection.setLabel("RAS");
+        enforcingService.setRasConnection(rasConnection);
+
+        String data = "{\"access_token\":\"" + testAccessToken + "\", \"active\":true, \"id_token\":\"SomeRandomToken\"}";
+        String payload = "token_type_hint=access_token&token=" + testAccessToken;
+        String redirectUri = "https://" + testDomain + "/login/loading";
+        String queryString = "grant_type=authorization_code" + "&code=" + code + "&redirect_uri=" + redirectUri;
+        String introspectionResponse =
+                "{\"active\":true,\"sub\":\"example_email@test.com\"," +
+                "\"acr\":\"https://stsstg.nih.gov/assurance/aal/1 https://stsstg.nih.gov/assurance/ial/1\"," +
+                "\"userid\":\"test_userid\",\"preferred_username\":\"testuser\"," +
+                "\"passport_jwt_v11\":\"" + exampleRasPassport + "\"}";
+
+        when(restClientUtil.retrievePostResponse(anyString(), any(), eq(queryString))).thenReturn(ResponseEntity.ok(data));
+        when(restClientUtil.retrievePostResponse(anyString(), any(), eq(payload))).thenReturn(ResponseEntity.ok(introspectionResponse));
+
+        // Full downstream stubs so that WITHOUT the gate the flow would succeed and return non-null.
+        User user = createTestUser();
+        user.setSubject("okta-ras|adfadfaf");
+        when(userService.createRasUser(any(), any())).thenReturn(Optional.of(user));
+        when(userService.updateUserRoles(any(), any())).thenReturn(user);
+        when(userService.updateUserConsents(any(), any())).thenReturn(user);
+        when(userService.getUserProfileResponse(any())).thenReturn(new HashMap<>());
+
+        HashMap<String, String> result = enforcingService.authenticate(authRequest, testDomain);
+
+        assertNull(result, "Login must be rejected when IAL2 is enforced and assurance is below AAL2/IAL2");
+        verify(userService, never()).createRasUser(any(), any());
+    }
+
+    @Test
     public void testAuthenticate_rejectsPassportWithInvalidSignature() {
         // RAS passport whose JWT signature does not verify against RAS's JWKS must block login,
         // before any role/permission is granted from its (untrusted) dbGaP claims.
@@ -167,6 +243,39 @@ public class RASAuthenticationServiceTest {
 
         assertNull(authenticate, "Login must be rejected when the passport signature is invalid");
         // No roles may be granted off an unverified passport.
+        verify(userService, never()).updateUserRoles(any(), any());
+    }
+
+    @Test
+    public void testAuthenticate_rejectsPassportWithInvalidVisaSignature() {
+        // The outer passport signature is valid, but an embedded visa's signature is not.
+        // The login must still be rejected before any role is granted.
+        String visa = JWTUtil.parsePassportJWTV11(exampleRasPassport).get().getGa4ghPassportV1().get(0);
+        when(rasPassportSignatureVerifier.isSignatureValid(visa)).thenReturn(false);
+
+        String data = "{\"access_token\":\"" + testAccessToken + "\", \"active\":true, \"id_token\":\"SomeRandomToken\"}";
+        String payload = "token_type_hint=access_token&token=" + testAccessToken;
+        String redirectUri = "https://" + testDomain + "/login/loading";
+        String queryString = "grant_type=authorization_code" + "&code=" + code + "&redirect_uri=" + redirectUri;
+        String introspectionResponse =
+                "{\"active\":true,\"sub\":\"example_email@test.com\",\"client_id\":\"test_client_id\"," +
+                "\"userid\":\"test_userid\",\"preferred_username\":\"testuser\"," +
+                "\"passport_jwt_v11\":\"" + exampleRasPassport + "\"}";
+
+        when(restClientUtil.retrievePostResponse(anyString(), any(), eq(queryString))).thenReturn(ResponseEntity.ok(data));
+        when(restClientUtil.retrievePostResponse(anyString(), any(), eq(payload))).thenReturn(ResponseEntity.ok(introspectionResponse));
+
+        // Full downstream stubs so that WITHOUT per-visa verification the flow would succeed.
+        User user = createTestUser();
+        user.setSubject("okta-ras|adfadfaf");
+        when(userService.createRasUser(any(), any())).thenReturn(Optional.of(user));
+        when(userService.updateUserRoles(any(), any())).thenReturn(user);
+        when(userService.updateUserConsents(any(), any())).thenReturn(user);
+        when(userService.getUserProfileResponse(any())).thenReturn(new HashMap<>());
+
+        HashMap<String, String> result = rasAuthenticationService.authenticate(authRequest, testDomain);
+
+        assertNull(result, "Login must be rejected when an embedded visa signature is invalid");
         verify(userService, never()).updateUserRoles(any(), any());
     }
 

--- a/pic-sure-auth-services/src/test/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/authentication/RASAuthenticationServiceTest.java
+++ b/pic-sure-auth-services/src/test/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/authentication/RASAuthenticationServiceTest.java
@@ -53,6 +53,9 @@ public class RASAuthenticationServiceTest {
     @MockBean
     private LoggingClient loggingClient;
 
+    @MockBean
+    private RasPassportSignatureVerifier rasPassportSignatureVerifier;
+
     private RASPassPortService rasPassPortService;
     private RASAuthenticationService rasAuthenticationService;
 
@@ -69,6 +72,8 @@ public class RASAuthenticationServiceTest {
         this.rasPassPortService = spy(new RASPassPortService(restClientUtil, userService, "", cacheEvictionService, null));
         doReturn(false).when(rasPassPortService).isExpired(any());
 
+        when(rasPassportSignatureVerifier.isSignatureValid(any())).thenReturn(true);
+
         rasAuthenticationService = new RASAuthenticationService(
                 userService,
                 restClientUtil,
@@ -80,6 +85,7 @@ public class RASAuthenticationServiceTest {
                 "https://stsstg.nih.gov",
                 roleService,
                 rasPassPortService,
+                rasPassportSignatureVerifier,
                 connectionService,
                 cacheEvictionService
         );
@@ -133,6 +139,35 @@ public class RASAuthenticationServiceTest {
         assertEquals("test@email.com", capturedClaims.getEmail());
         assertEquals("RAS", capturedClaims.getIdp());
         assertEquals("https://ncbi.nlm.nih.gov/gap", capturedClaims.getUser_permission_group());
+    }
+
+    @Test
+    public void testAuthenticate_rejectsPassportWithInvalidSignature() {
+        // RAS passport whose JWT signature does not verify against RAS's JWKS must block login,
+        // before any role/permission is granted from its (untrusted) dbGaP claims.
+        when(rasPassportSignatureVerifier.isSignatureValid(any())).thenReturn(false);
+
+        String data = "{\"access_token\":\"" + testAccessToken + "\", \"active\":true, \"id_token\":\"SomeRandomToken\"}";
+        String payload = "token_type_hint=access_token&token=" + testAccessToken;
+        String redirectUri = "https://" + testDomain + "/login/loading";
+        String queryString = "grant_type=authorization_code" + "&code=" + code + "&redirect_uri=" + redirectUri;
+        String introspectionResponse =
+                "{\"active\":true,\"sub\":\"example_email@test.com\",\"client_id\":\"test_client_id\"," +
+                "\"userid\":\"test_userid\",\"preferred_username\":\"testuser\"," +
+                "\"passport_jwt_v11\":\"" + exampleRasPassport + "\"}";
+
+        when(restClientUtil.retrievePostResponse(anyString(), any(), eq(queryString))).thenReturn(ResponseEntity.ok(data));
+        when(restClientUtil.retrievePostResponse(anyString(), any(), eq(payload))).thenReturn(ResponseEntity.ok(introspectionResponse));
+
+        User user = createTestUser();
+        user.setSubject("okta-ras|adfadfaf");
+        when(userService.createRasUser(any(), any())).thenReturn(Optional.of(user));
+
+        HashMap<String, String> authenticate = rasAuthenticationService.authenticate(authRequest, testDomain);
+
+        assertNull(authenticate, "Login must be rejected when the passport signature is invalid");
+        // No roles may be granted off an unverified passport.
+        verify(userService, never()).updateUserRoles(any(), any());
     }
 
     @Test


### PR DESCRIPTION
## Summary

Hardens RAS passport handling. Previously RAS passport JWTs were **never cryptographically verified** — they were only Base64-decoded, and the dbGaP permissions that drive data-access roles were trusted straight out of an unauthenticated payload. (The pre-existing `*PassPortServiceTest` fixtures literally used `.fakesignature` as their signature segment and still passed.)

Because **Okta brokers the RAS connection**, RAS's signature on the passport/visas is the only end-to-end guarantee that the dbGaP permissions were issued by RAS and not tampered with in transit.

## Changes

**Commit 1 — passport signature verification at login**
- **New `RasPassportSignatureVerifier`** — OIDC-discovers RAS's `jwks_uri` from `${ras.passport.issuer}/.well-known/openid-configuration`, caches keys by `kid` (refresh on rotation), RS256-verifies a passport JWT. **Fails closed**: blank token, unknown `kid`, malformed token, expired token, or any signature mismatch → rejected.
- **`RASAuthenticationService.extractAndVerifyPassport()`** gates on signature validity; an invalid signature blocks login **before** any role/permission is granted.
- **`RASPassPortService.isExpired()` fix** — was `exp < now && iat < now`, so a future/malformed `iat` masked an expired passport. Now `exp < now`.

**Commit 2 — hardening follow-ups**
- **IAL2/AAL2 enforcement** (opt-in via `ras.enforce.ial2`, default **false**) — parses the `acr` claim and requires AAL ≥ 2 and IAL ≥ 2 for RAS logins. Default-off so IAL1-only IdPs (eRA Commons, Google) aren't locked out until a deployment opts in. Scoped to RAS login flows only.
- **Per-visa signature verification** — every embedded GA4GH visa is verified at login, not just the outer passport, so a tampered visa cannot grant dbGaP permissions.
- **Polling validate-all-visas fix** — `validateUserPassport` previously returned after the first visa; it now validates every visa, so a later invalid visa is caught.

The existing `/passport/validate` polling (RAS server-side check during the session) is unchanged, so verification is layered: **local signature check + IAL2 + per-visa at login, plus server-side validation during the session.**

## Tests

- `RasPassportSignatureVerifierTest` — accept a key-signed passport; reject tampered-payload, wrong-key, forged-signature (real RSA keypair + mocked JWKS).
- `RASAuthenticationServiceTest` — reject login on invalid passport signature, invalid visa signature, and (when enforced) sub-IAL2 assurance; `acr` parsing cases.
- `RASPassPortServiceTest` — `isExpired` cases; multi-visa polling invalidate-on-any-invalid and validate-all.
- Full module suite: **325 passing, 0 failures.**

## Config
- `ras.enforce.ial2` (env `RAS_ENFORCE_IAL2`, default `false`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Added signature verification for RAS passports and embedded visas.
  * Authentication now rejects tampered, invalid, or improperly signed credentials.
  * Added optional enforcement of AAL2/IAL2 assurance requirements.

* **Bug Fixes**
  * Transient RAS service errors no longer incorrectly invalidate passports or log users out.
  * Passport visa validation now processes all visas consistently.
  * Improved handling of missing visas and expiration data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->