### PR TITLE
feat: record adapter caller (X-Client-Type) in audit log metadata

### DIFF
--- a/pic-sure-auth-services/pom.xml
+++ b/pic-sure-auth-services/pom.xml
@@ -237,7 +237,7 @@
         <dependency>
             <groupId>edu.harvard.dbmi.avillach</groupId>
             <artifactId>pic-sure-logging-client</artifactId>
-            <version>1.0.0</version>
+            <version>1.1.0</version>
         </dependency>
     </dependencies>
 

--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/filter/AuditLoggingFilter.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/filter/AuditLoggingFilter.java
@@ -132,6 +132,15 @@ public class AuditLoggingFilter extends OncePerRequestFilter {
                 }
             }
 
+            // Originating caller (e.g. PYTHON_ADAPTER / R_ADAPTER), set by the
+            // adapters via the X-Client-Type header. Recorded as "caller" to
+            // distinguish it from the top-level client_type, which identifies
+            // the emitting service.
+            String caller = request.getHeader("X-Client-Type");
+            if (caller != null && !caller.isEmpty()) {
+                metadata.put("caller", caller);
+            }
+
             // Session ID
             String sessionId = SessionIdResolver.resolve(request.getHeader("X-Session-Id"), srcIp, request.getHeader("User-Agent"));
 

--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/filter/AuditLoggingFilter.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/filter/AuditLoggingFilter.java
@@ -134,9 +134,6 @@ public class AuditLoggingFilter extends OncePerRequestFilter {
 
             // Originating caller (e.g. PYTHON_ADAPTER / R_ADAPTER)
             String caller = request.getHeader("X-Client-Type");
-            if (caller != null && !caller.isEmpty()) {
-                metadata.put("caller", caller);
-            }
 
             // Session ID
             String sessionId = SessionIdResolver.resolve(request.getHeader("X-Session-Id"), srcIp, request.getHeader("User-Agent"));
@@ -156,6 +153,10 @@ public class AuditLoggingFilter extends OncePerRequestFilter {
             // Build the event
             LoggingEvent.Builder eventBuilder =
                 LoggingEvent.builder(eventType).action(action).sessionId(sessionId).request(requestInfo).metadata(metadata);
+
+            if (caller != null && !caller.isEmpty()) {
+                eventBuilder.caller(caller);
+            }
 
             if (errorMap != null) {
                 eventBuilder.error(errorMap);

--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/filter/AuditLoggingFilter.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/filter/AuditLoggingFilter.java
@@ -132,10 +132,7 @@ public class AuditLoggingFilter extends OncePerRequestFilter {
                 }
             }
 
-            // Originating caller (e.g. PYTHON_ADAPTER / R_ADAPTER), set by the
-            // adapters via the X-Client-Type header. Recorded as "caller" to
-            // distinguish it from the top-level client_type, which identifies
-            // the emitting service.
+            // Originating caller (e.g. PYTHON_ADAPTER / R_ADAPTER)
             String caller = request.getHeader("X-Client-Type");
             if (caller != null && !caller.isEmpty()) {
                 metadata.put("caller", caller);

--- a/pic-sure-auth-services/src/test/java/edu/harvard/hms/dbmi/avillach/auth/filter/AuditLoggingFilterTest.java
+++ b/pic-sure-auth-services/src/test/java/edu/harvard/hms/dbmi/avillach/auth/filter/AuditLoggingFilterTest.java
@@ -91,6 +91,35 @@ class AuditLoggingFilterTest {
     }
 
     @Test
+    void shouldRecordClientTypeFromHeader() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/user/me");
+        request.setAttribute(AuditAttributes.EVENT_TYPE, "ACCESS");
+        request.setAttribute(AuditAttributes.ACTION, "user.profile");
+        request.addHeader("X-Client-Type", "PYTHON_ADAPTER");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        filter.doFilter(request, response, filterChain);
+
+        ArgumentCaptor<LoggingEvent> captor = ArgumentCaptor.forClass(LoggingEvent.class);
+        verify(loggingClient).send(captor.capture());
+        assertEquals("PYTHON_ADAPTER", captor.getValue().getMetadata().get("caller"));
+    }
+
+    @Test
+    void shouldOmitCallerWhenHeaderAbsent() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/user/me");
+        request.setAttribute(AuditAttributes.EVENT_TYPE, "ACCESS");
+        request.setAttribute(AuditAttributes.ACTION, "user.profile");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        filter.doFilter(request, response, filterChain);
+
+        ArgumentCaptor<LoggingEvent> captor = ArgumentCaptor.forClass(LoggingEvent.class);
+        verify(loggingClient).send(captor.capture());
+        assertFalse(captor.getValue().getMetadata().containsKey("caller"));
+    }
+
+    @Test
     void shouldCategorizeAdminUserModify() throws Exception {
         MockHttpServletRequest request = new MockHttpServletRequest("POST", "/user");
         request.setAttribute(AuditAttributes.EVENT_TYPE, "ADMIN");

--- a/pic-sure-auth-services/src/test/java/edu/harvard/hms/dbmi/avillach/auth/filter/AuditLoggingFilterTest.java
+++ b/pic-sure-auth-services/src/test/java/edu/harvard/hms/dbmi/avillach/auth/filter/AuditLoggingFilterTest.java
@@ -102,7 +102,7 @@ class AuditLoggingFilterTest {
 
         ArgumentCaptor<LoggingEvent> captor = ArgumentCaptor.forClass(LoggingEvent.class);
         verify(loggingClient).send(captor.capture());
-        assertEquals("PYTHON_ADAPTER", captor.getValue().getMetadata().get("caller"));
+        assertEquals("PYTHON_ADAPTER", captor.getValue().getCaller());
     }
 
     @Test
@@ -116,7 +116,7 @@ class AuditLoggingFilterTest {
 
         ArgumentCaptor<LoggingEvent> captor = ArgumentCaptor.forClass(LoggingEvent.class);
         verify(loggingClient).send(captor.capture());
-        assertFalse(captor.getValue().getMetadata().containsKey("caller"));
+        assertNull(captor.getValue().getCaller());
     }
 
     @Test


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Audit logs now include the client type from the `X-Client-Type` request header when provided, improving traceability.
* **Bug Fixes**
  * Requests that omit the `X-Client-Type` header continue to be logged without adding a caller value.
* **Tests**
  * Added coverage to verify audit logging captures the `caller` field based on presence or absence of the `X-Client-Type` header.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->