### PR TITLE
WIP: Phase 3 — segment-aware HPDS-v3 consent-skip

### DIFF
--- a/pic-sure-auth-services/pom.xml
+++ b/pic-sure-auth-services/pom.xml
@@ -81,6 +81,10 @@
             <artifactId>spring-boot-starter-security</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.github.spullara.mustache.java</groupId>
             <artifactId>compiler</artifactId>
             <version>0.9.5</version>

--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/authorization/AuthorizationService.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/authorization/AuthorizationService.java
@@ -19,6 +19,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import java.util.*;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import static edu.harvard.hms.dbmi.avillach.auth.service.impl.RoleService.*;
@@ -45,6 +46,14 @@ import static edu.harvard.hms.dbmi.avillach.auth.service.impl.RoleService.*;
 public class AuthorizationService {
 
     private final Logger logger = LoggerFactory.getLogger(AuthorizationService.class);
+
+    /**
+     * Matches clean HPDS-v3 target service paths, e.g. {@code /hpds/auth/v3}, {@code /hpds/auth/v3/query},
+     * {@code /hpds/open/v3}, {@code /hpds/open/v3/query/abc/result}. Intentionally segment-aware so it does
+     * NOT match things like {@code /hpds/auth/v30/query}, {@code /hpds/auth/v3ish/query},
+     * {@code /hpds/v3/query}, {@code /foo/hpds/auth/v3/query}, or {@code /hpds/auth/v3-query}.
+     */
+    private static final Pattern HPDS_V3_TARGET_SERVICE_PATTERN = Pattern.compile("^/hpds/(auth|open)/v3(/.*)?$");
 
     protected AccessRuleService accessRuleService;
     protected SessionService sessionService;
@@ -235,7 +244,7 @@ public class AuthorizationService {
                 else {
                     String targetService = (String) ((Map) requestBody).get("Target Service");
                     logger.debug("Target service = " + targetService);
-                    if (targetService != null && targetService.startsWith("/v3")) {
+                    if (targetService != null && (targetService.startsWith("/v3") || isHpdsV3TargetService(targetService))) {
                         logger.debug("Skipping access rule {}", accessRule.getName());
                     }
                     else if (this.accessRuleService.evaluateAccessRule(requestBody, accessRule)) {
@@ -274,6 +283,20 @@ public class AuthorizationService {
         return new EvaluateAccessRuleResult(result, failedRules, passRuleName, Optional.ofNullable(returnQuery));
     }
 
+    /**
+     * Returns true only when {@code targetService} is a clean HPDS-v3 target service path, i.e. exactly
+     * {@code /hpds/auth/v3}, {@code /hpds/auth/v3/**}, {@code /hpds/open/v3}, or {@code /hpds/open/v3/**}.
+     * <p>
+     * This is intentionally segment/prefix-aware (not a loose {@code contains("hpds") && contains("v3")}
+     * check) so that consent-rule evaluation is skipped only for genuine HPDS-v3 calls, not for
+     * unrelated paths that happen to contain those substrings.
+     */
+    static boolean isHpdsV3TargetService(String targetService) {
+        if (targetService == null) {
+            return false;
+        }
+        return HPDS_V3_TARGET_SERVICE_PATTERN.matcher(targetService).matches();
+    }
 
     public boolean openAccessRequestIsValid(Map<String, Object> inputMap) {
 

--- a/pic-sure-auth-services/src/main/resources/application.properties
+++ b/pic-sure-auth-services/src/main/resources/application.properties
@@ -128,3 +128,6 @@ server.servlet.session.cookie.secure=true
 
 spring.devtools.remote.secret=${DEVTOOLS_SECRET:false}
 spring.devtools.remote.context-path=/remote
+
+# Mail-send failures must not gate service health (SMTP unreachable in some envs); actuator mail indicator off.
+management.health.mail.enabled=false

--- a/pic-sure-auth-services/src/main/resources/application.properties
+++ b/pic-sure-auth-services/src/main/resources/application.properties
@@ -2,6 +2,11 @@
 server.port=${SERVER_PORT:8090}
 server.servlet.context-path=/auth
 
+# Actuator health/info endpoints (available at /auth/actuator/health, /auth/actuator/info)
+management.endpoints.web.exposure.include=health,info
+management.endpoint.health.show-details=always
+management.endpoint.health.probes.enabled=true
+
 spring.datasource.url=${DATASOURCE_URL:jdbc:mysql://picsure-db:3306/auth?useUnicode=true&characterEncoding=UTF-8&autoReconnect=true&autoReconnectForPools=true&serverTimezone=UTC}
 spring.datasource.username=${DATASOURCE_USERNAME:root}
 spring.datasource.password=${DATASOURCE_PASSWORD:password}

--- a/pic-sure-auth-services/src/test/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/authorization/AuthorizationServiceHpdsV3TargetServiceTest.java
+++ b/pic-sure-auth-services/src/test/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/authorization/AuthorizationServiceHpdsV3TargetServiceTest.java
@@ -1,0 +1,79 @@
+package edu.harvard.hms.dbmi.avillach.auth.service.impl.authorization;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for {@link AuthorizationService#isHpdsV3TargetService(String)}.
+ * <p>
+ * This helper controls when the HPDS-v3 consent-based access rule check is skipped, so it must
+ * match clean HPDS-v3 target service paths precisely (segment-aware), without being fooled by
+ * substrings like "v30", "v3ish", or paths where "hpds"/"v3" appear in the wrong position.
+ */
+class AuthorizationServiceHpdsV3TargetServiceTest {
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "/hpds/auth/v3",
+            "/hpds/auth/v3/query",
+            "/hpds/open/v3",
+            "/hpds/open/v3/query/abc/result",
+            "/hpds/auth/v3/"
+    })
+    void returnsTrueForCleanHpdsV3Paths(String targetService) {
+        assertTrue(AuthorizationService.isHpdsV3TargetService(targetService));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "/dictionary/v3/hpds",
+            "/hpds/auth/v30/query",
+            "/hpds/auth/v3ish/query",
+            "/hpds/v3/query",
+            "/foo/hpds/auth/v3/query",
+            "/hpds/auth/v3-query",
+            "/v3/query"
+    })
+    void returnsFalseForNonMatchingPaths(String targetService) {
+        assertFalse(AuthorizationService.isHpdsV3TargetService(targetService));
+    }
+
+    @Test
+    void returnsFalseForNull() {
+        assertFalse(AuthorizationService.isHpdsV3TargetService(null));
+    }
+
+    @Test
+    void legacyV3PrefixIsNotMatchedByHelperButIsHandledSeparatelyByStartsWith() {
+        // isHpdsV3TargetService is intentionally narrow; the legacy "/v3" prefix continues to be
+        // handled by the separate startsWith("/v3") check in passesAccessRuleEvaluation until Phase 7.
+        assertFalse(AuthorizationService.isHpdsV3TargetService("/v3/query"));
+    }
+
+    @Test
+    void combinedSkipPredicate_legacyV3PathSkips() {
+        assertTrue(skipsConsentCheck("/v3/query"));
+    }
+
+    @Test
+    void combinedSkipPredicate_cleanHpdsV3PathSkips() {
+        assertTrue(skipsConsentCheck("/hpds/auth/v3/query"));
+    }
+
+    @Test
+    void combinedSkipPredicate_unrelatedPathDoesNotSkip() {
+        assertFalse(skipsConsentCheck("/dictionary/x"));
+    }
+
+    /**
+     * Mirrors the skip condition used in {@link AuthorizationService#passesAccessRuleEvaluation}.
+     */
+    private static boolean skipsConsentCheck(String targetService) {
+        return targetService != null
+                && (targetService.startsWith("/v3") || AuthorizationService.isHpdsV3TargetService(targetService));
+    }
+}


### PR DESCRIPTION
**WIP / draft** — Phase 3: segment/prefix-aware HPDS-v3 consent-skip in `AuthorizationService`.
Adds `isHpdsV3TargetService` matching `^/hpds/(auth|open)/v3(/.*)?$`, OR'd with the retained legacy `startsWith("/v3")` (removed in Phase 7). Rejects over-match candidates (`/hpds/auth/v30`, `/hpds/auth/v3ish`, `/hpds/v3/query`, `/foo/hpds/auth/v3/...`, `/dictionary/v3/hpds`). 17 new unit tests; full module suite (326) green. Forward-compat for the Phase-3/4 clean HPDS-v3 paths. Stacked per design spec §9.
