### PR TITLE
[ALS-12357] Open-access API keys: schema, service, endpoints, enforcement

### DIFF
--- a/pic-sure-auth-db/db/sql/V10__CREATE_API_KEY_TABLE.sql
+++ b/pic-sure-auth-db/db/sql/V10__CREATE_API_KEY_TABLE.sql
@@ -1,0 +1,15 @@
+CREATE TABLE api_key (
+   `uuid` binary(16) NOT NULL,
+   `key_hash` varchar(64) NOT NULL,
+   `hash_scheme` varchar(16) NOT NULL,
+   `display_prefix` varchar(8) NOT NULL,
+   `key_type` varchar(16) NOT NULL,
+   `name` varchar(255),
+   `email` varchar(255),
+   `created_at` datetime NOT NULL,
+   `expires_at` datetime NOT NULL,
+   `revoked_at` datetime,
+   `last_used_at` datetime,
+   PRIMARY KEY (`uuid`),
+   UNIQUE KEY `uk_api_key_hash` (`key_hash`)
+);

--- a/pic-sure-auth-db/db/sql/V10__CREATE_API_KEY_TABLE.sql
+++ b/pic-sure-auth-db/db/sql/V10__CREATE_API_KEY_TABLE.sql
@@ -7,10 +7,12 @@ CREATE TABLE api_key (
    `name` varchar(255),
    `email` varchar(255),
    `created_at` datetime NOT NULL,
-   `expires_at` datetime NOT NULL,
+   `expires_at` datetime,
    `revoked_at` datetime,
    `last_used_at` datetime,
    PRIMARY KEY (`uuid`),
    UNIQUE KEY `uk_api_key_hash` (`key_hash`),
-   KEY `idx_api_key_key_type_created_at` (`key_type`, `created_at`)
+   KEY `idx_api_key_key_type_created_at` (`key_type`, `created_at`),
+   -- NULL expires_at means "never expires" and is an explicit opt-in for PLATFORM keys only
+   CONSTRAINT `ck_api_key_user_key_expires` CHECK (`key_type` = 'PLATFORM' OR `expires_at` IS NOT NULL)
 );

--- a/pic-sure-auth-db/db/sql/V10__CREATE_API_KEY_TABLE.sql
+++ b/pic-sure-auth-db/db/sql/V10__CREATE_API_KEY_TABLE.sql
@@ -11,5 +11,6 @@ CREATE TABLE api_key (
    `revoked_at` datetime,
    `last_used_at` datetime,
    PRIMARY KEY (`uuid`),
-   UNIQUE KEY `uk_api_key_hash` (`key_hash`)
+   UNIQUE KEY `uk_api_key_hash` (`key_hash`),
+   KEY `idx_api_key_key_type_created_at` (`key_type`, `created_at`)
 );

--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/config/ApplicationConfig.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/config/ApplicationConfig.java
@@ -1,7 +1,11 @@
 package edu.harvard.hms.dbmi.avillach.auth.config;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import edu.harvard.hms.dbmi.avillach.auth.service.impl.CustomUserDetailService;
+
+import java.time.Instant;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.cache.interceptor.KeyGenerator;
@@ -42,6 +46,12 @@ public class ApplicationConfig {
 
     @Bean
     public ObjectMapper objectMapper() {
-        return new ObjectMapper();
+        // this bean replaces Boot's auto-configured mapper, which would otherwise register
+        // java.time support itself; without JavaTimeModule any Instant field fails (de)serialization.
+        // Instant renders as an ISO-8601 string; the shape is overridden per-type rather than via
+        // WRITE_DATES_AS_TIMESTAMPS so legacy java.util.Date fields keep their epoch-millis rendering.
+        ObjectMapper objectMapper = new ObjectMapper().registerModule(new JavaTimeModule());
+        objectMapper.configOverride(Instant.class).setFormat(JsonFormat.Value.forShape(JsonFormat.Shape.STRING));
+        return objectMapper;
     }
 }

--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/config/SecurityConfig.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/config/SecurityConfig.java
@@ -57,7 +57,8 @@ public class SecurityConfig {
             .authorizeHttpRequests(
                 (authorizeRequests) -> authorizeRequests.requestMatchers(
                     "/actuator/health", "/actuator/info", "/authentication", "/authentication/**", "/swagger.yaml", "/swagger.json",
-                    "/user/me/queryTemplate", "/user/me/queryTemplate/**", "/tos/latest", "/open/validate", "/logout", "/cache/**"
+                    "/user/me/queryTemplate", "/user/me/queryTemplate/**", "/tos/latest", "/open/validate", "/open/apiKey", "/logout",
+                    "/cache/**"
                 ).permitAll().anyRequest().authenticated()
             ).httpBasic(AbstractHttpConfigurer::disable).formLogin(AbstractHttpConfigurer::disable)
             // AuditLoggingFilter must wrap the entire chain (including LogoutFilter and JWTFilter)

--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/entity/ApiKey.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/entity/ApiKey.java
@@ -33,7 +33,8 @@ public class ApiKey extends BaseEntity {
     @Column(name = "created_at", nullable = false)
     private Instant createdAt;
 
-    @Column(name = "expires_at", nullable = false)
+    // null means the key never expires (explicit opt-in, PLATFORM keys only)
+    @Column(name = "expires_at")
     private Instant expiresAt;
 
     @Column(name = "revoked_at")

--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/entity/ApiKey.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/entity/ApiKey.java
@@ -1,0 +1,134 @@
+package edu.harvard.hms.dbmi.avillach.auth.entity;
+
+import edu.harvard.hms.dbmi.avillach.auth.enums.ApiKeyType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+
+import java.time.Instant;
+
+@Entity(name = "api_key")
+public class ApiKey extends BaseEntity {
+
+    @Column(name = "key_hash", unique = true, nullable = false, length = 64)
+    private String keyHash;
+
+    @Column(name = "hash_scheme", nullable = false, length = 16)
+    private String hashScheme;
+
+    @Column(name = "display_prefix", nullable = false, length = 8)
+    private String displayPrefix;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "key_type", nullable = false, length = 16)
+    private ApiKeyType keyType;
+
+    @Column(name = "name")
+    private String name;
+
+    @Column(name = "email")
+    private String email;
+
+    @Column(name = "created_at", nullable = false)
+    private Instant createdAt;
+
+    @Column(name = "expires_at", nullable = false)
+    private Instant expiresAt;
+
+    @Column(name = "revoked_at")
+    private Instant revokedAt;
+
+    @Column(name = "last_used_at")
+    private Instant lastUsedAt;
+
+    public String getKeyHash() {
+        return keyHash;
+    }
+
+    public ApiKey setKeyHash(String keyHash) {
+        this.keyHash = keyHash;
+        return this;
+    }
+
+    public String getHashScheme() {
+        return hashScheme;
+    }
+
+    public ApiKey setHashScheme(String hashScheme) {
+        this.hashScheme = hashScheme;
+        return this;
+    }
+
+    public String getDisplayPrefix() {
+        return displayPrefix;
+    }
+
+    public ApiKey setDisplayPrefix(String displayPrefix) {
+        this.displayPrefix = displayPrefix;
+        return this;
+    }
+
+    public ApiKeyType getKeyType() {
+        return keyType;
+    }
+
+    public ApiKey setKeyType(ApiKeyType keyType) {
+        this.keyType = keyType;
+        return this;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public ApiKey setName(String name) {
+        this.name = name;
+        return this;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public ApiKey setEmail(String email) {
+        this.email = email;
+        return this;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public ApiKey setCreatedAt(Instant createdAt) {
+        this.createdAt = createdAt;
+        return this;
+    }
+
+    public Instant getExpiresAt() {
+        return expiresAt;
+    }
+
+    public ApiKey setExpiresAt(Instant expiresAt) {
+        this.expiresAt = expiresAt;
+        return this;
+    }
+
+    public Instant getRevokedAt() {
+        return revokedAt;
+    }
+
+    public ApiKey setRevokedAt(Instant revokedAt) {
+        this.revokedAt = revokedAt;
+        return this;
+    }
+
+    public Instant getLastUsedAt() {
+        return lastUsedAt;
+    }
+
+    public ApiKey setLastUsedAt(Instant lastUsedAt) {
+        this.lastUsedAt = lastUsedAt;
+        return this;
+    }
+}

--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/enums/ApiKeyType.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/enums/ApiKeyType.java
@@ -1,0 +1,6 @@
+package edu.harvard.hms.dbmi.avillach.auth.enums;
+
+public enum ApiKeyType {
+    USER,
+    PLATFORM
+}

--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/exceptions/GlobalExceptionHandler.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/exceptions/GlobalExceptionHandler.java
@@ -12,8 +12,11 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.HttpServerErrorException;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 import java.sql.SQLIntegrityConstraintViolationException;
+import java.util.Arrays;
+import java.util.stream.Collectors;
 
 /**
  * Global exception handler for the PICSURE Auth application.
@@ -75,8 +78,32 @@ public class GlobalExceptionHandler {
     }
     
     /**
+     * Handles request parameter type mismatches (e.g. a non-numeric page number or an unknown
+     * enum value), which are client errors — without this, they fall through to the
+     * RuntimeException handler as 500s.
+     *
+     * @param ex The exception thrown during parameter binding
+     * @return A response with HTTP 400 Bad Request status naming the parameter and expected type
+     */
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<?> handleTypeMismatch(MethodArgumentTypeMismatchException ex) {
+        Class<?> requiredType = ex.getRequiredType();
+        // the offending value is client-controlled; keep it out of the log and the response
+        String expected = requiredType == null ? "a different type"
+            : requiredType.isEnum()
+                ? "one of " + Arrays.stream(requiredType.getEnumConstants()).map(Object::toString).collect(Collectors.joining(", "))
+                : "a " + requiredType.getSimpleName();
+        logger.warn("Type mismatch for request parameter '{}': expected {}", ex.getName(), expected);
+        return PICSUREResponse.error(
+            HttpStatus.BAD_REQUEST,
+            "Invalid value for parameter '" + ex.getName() + "'",
+            "Expected " + expected + "."
+        );
+    }
+
+    /**
      * Handles IllegalArgumentException, which is commonly used for validation errors.
-     * 
+     *
      * @param ex The exception
      * @return A response with HTTP 400 Bad Request status
      */

--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/exceptions/GlobalExceptionHandler.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/exceptions/GlobalExceptionHandler.java
@@ -10,6 +10,7 @@ import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.HttpServerErrorException;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
@@ -85,6 +86,21 @@ public class GlobalExceptionHandler {
      * @param ex The exception thrown during parameter binding
      * @return A response with HTTP 400 Bad Request status naming the parameter and expected type
      */
+    /**
+     * Handles unreadable request bodies (malformed JSON, missing body, unparseable field values),
+     * which are client errors — without this they reach the RuntimeException handler as 500s and
+     * could leak parser internals in the response.
+     *
+     * @param ex The exception thrown during message conversion
+     * @return A response with HTTP 400 Bad Request status and no parser details
+     */
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<?> handleUnreadableBody(HttpMessageNotReadableException ex) {
+        // the parser message can embed the raw (client-controlled) payload; log and return only a generic error
+        logger.warn("Rejected unreadable request body");
+        return PICSUREResponse.error(HttpStatus.BAD_REQUEST, "Malformed request body", "The request body could not be parsed.");
+    }
+
     @ExceptionHandler(MethodArgumentTypeMismatchException.class)
     public ResponseEntity<?> handleTypeMismatch(MethodArgumentTypeMismatchException ex) {
         Class<?> requiredType = ex.getRequiredType();

--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/model/request/PlatformApiKeyRequest.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/model/request/PlatformApiKeyRequest.java
@@ -1,0 +1,6 @@
+package edu.harvard.hms.dbmi.avillach.auth.model.request;
+
+import java.time.Instant;
+
+public record PlatformApiKeyRequest(String name, String email, Instant expiresAt) {
+}

--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/model/request/PlatformApiKeyRequest.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/model/request/PlatformApiKeyRequest.java
@@ -2,5 +2,11 @@ package edu.harvard.hms.dbmi.avillach.auth.model.request;
 
 import java.time.Instant;
 
-public record PlatformApiKeyRequest(String name, String email, Instant expiresAt) {
+/**
+ * A never-expiring key must be an explicit opt-in via {@code neverExpires}: after Jackson binding,
+ * an absent {@code expiresAt} is indistinguishable from an explicit null, and "no expiry chosen"
+ * must default to the configured platform TTL rather than silently minting a non-expiring key.
+ * Setting both fields is rejected.
+ */
+public record PlatformApiKeyRequest(String name, String email, Instant expiresAt, boolean neverExpires) {
 }

--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/model/request/UserApiKeyRequest.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/model/request/UserApiKeyRequest.java
@@ -1,4 +1,4 @@
 package edu.harvard.hms.dbmi.avillach.auth.model.request;
 
-public record UserApiKeyRequest(String captchaToken, String email) {
+public record UserApiKeyRequest(String captchaToken, String name, String email) {
 }

--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/model/request/UserApiKeyRequest.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/model/request/UserApiKeyRequest.java
@@ -1,0 +1,4 @@
+package edu.harvard.hms.dbmi.avillach.auth.model.request;
+
+public record UserApiKeyRequest(String captchaToken, String email) {
+}

--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/model/response/ApiKeyCreationResponse.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/model/response/ApiKeyCreationResponse.java
@@ -1,0 +1,20 @@
+package edu.harvard.hms.dbmi.avillach.auth.model.response;
+
+import edu.harvard.hms.dbmi.avillach.auth.enums.ApiKeyType;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * The only place a plaintext API key ever appears. Returned once at creation; the key is
+ * not recoverable afterwards.
+ */
+public record ApiKeyCreationResponse(String apiKey, UUID uuid, String displayPrefix, ApiKeyType keyType, Instant expiresAt) {
+
+    // the default record toString would embed the plaintext key, one accidental log statement away from a leak
+    @Override
+    public String toString() {
+        return "ApiKeyCreationResponse[apiKey=REDACTED, uuid=%s, displayPrefix=%s, keyType=%s, expiresAt=%s]"
+            .formatted(uuid, displayPrefix, keyType, expiresAt);
+    }
+}

--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/model/response/ApiKeyMetadata.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/model/response/ApiKeyMetadata.java
@@ -1,0 +1,20 @@
+package edu.harvard.hms.dbmi.avillach.auth.model.response;
+
+import edu.harvard.hms.dbmi.avillach.auth.entity.ApiKey;
+import edu.harvard.hms.dbmi.avillach.auth.enums.ApiKeyType;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public record ApiKeyMetadata(
+    UUID uuid, String displayPrefix, ApiKeyType keyType, String name, String email, Instant createdAt, Instant expiresAt,
+    Instant revokedAt, Instant lastUsedAt
+) {
+
+    public static ApiKeyMetadata from(ApiKey apiKey) {
+        return new ApiKeyMetadata(
+            apiKey.getUuid(), apiKey.getDisplayPrefix(), apiKey.getKeyType(), apiKey.getName(), apiKey.getEmail(), apiKey.getCreatedAt(),
+            apiKey.getExpiresAt(), apiKey.getRevokedAt(), apiKey.getLastUsedAt()
+        );
+    }
+}

--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/model/response/ApiKeyPage.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/model/response/ApiKeyPage.java
@@ -1,0 +1,6 @@
+package edu.harvard.hms.dbmi.avillach.auth.model.response;
+
+import java.util.List;
+
+public record ApiKeyPage(List<ApiKeyMetadata> keys, long totalCount, int page, int size) {
+}

--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/repository/ApiKeyRepository.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/repository/ApiKeyRepository.java
@@ -9,7 +9,6 @@ import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Instant;
-import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -17,8 +16,6 @@ import java.util.UUID;
 public interface ApiKeyRepository extends JpaRepository<ApiKey, UUID> {
 
     Optional<ApiKey> findByKeyHash(String keyHash);
-
-    List<ApiKey> findAllByOrderByCreatedAtDesc();
 
     // dedicated single-column update: a save() of the entity loaded during verification would merge
     // every column, letting a stale revoked_at=null overwrite a concurrent revocation

--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/repository/ApiKeyRepository.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/repository/ApiKeyRepository.java
@@ -26,6 +26,9 @@ public interface ApiKeyRepository extends JpaRepository<ApiKey, UUID> {
     // every column, letting a stale revoked_at=null overwrite a concurrent revocation
     @Modifying
     @Transactional
-    @Query("UPDATE api_key k SET k.lastUsedAt = :now WHERE k.uuid = :uuid AND k.revokedAt IS NULL AND k.expiresAt > :now")
+    @Query(
+        "UPDATE api_key k SET k.lastUsedAt = :now WHERE k.uuid = :uuid AND k.revokedAt IS NULL"
+            + " AND (k.expiresAt IS NULL OR k.expiresAt > :now)"
+    )
     int touchLastUsed(@Param("uuid") UUID uuid, @Param("now") Instant now);
 }

--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/repository/ApiKeyRepository.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/repository/ApiKeyRepository.java
@@ -1,6 +1,9 @@
 package edu.harvard.hms.dbmi.avillach.auth.repository;
 
 import edu.harvard.hms.dbmi.avillach.auth.entity.ApiKey;
+import edu.harvard.hms.dbmi.avillach.auth.enums.ApiKeyType;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -16,6 +19,8 @@ import java.util.UUID;
 public interface ApiKeyRepository extends JpaRepository<ApiKey, UUID> {
 
     Optional<ApiKey> findByKeyHash(String keyHash);
+
+    Page<ApiKey> findByKeyType(ApiKeyType keyType, Pageable pageable);
 
     // dedicated single-column update: a save() of the entity loaded during verification would merge
     // every column, letting a stale revoked_at=null overwrite a concurrent revocation

--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/repository/ApiKeyRepository.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/repository/ApiKeyRepository.java
@@ -23,12 +23,14 @@ public interface ApiKeyRepository extends JpaRepository<ApiKey, UUID> {
     Page<ApiKey> findByKeyType(ApiKeyType keyType, Pageable pageable);
 
     // dedicated single-column update: a save() of the entity loaded during verification would merge
-    // every column, letting a stale revoked_at=null overwrite a concurrent revocation
+    // every column, letting a stale revoked_at=null overwrite a concurrent revocation. The cutoff
+    // makes the write throttle atomic — concurrent requests holding the same stale snapshot must
+    // not each issue an update
     @Modifying
     @Transactional
     @Query(
         "UPDATE api_key k SET k.lastUsedAt = :now WHERE k.uuid = :uuid AND k.revokedAt IS NULL"
-            + " AND (k.expiresAt IS NULL OR k.expiresAt > :now)"
+            + " AND (k.expiresAt IS NULL OR k.expiresAt > :now)" + " AND (k.lastUsedAt IS NULL OR k.lastUsedAt < :cutoff)"
     )
-    int touchLastUsed(@Param("uuid") UUID uuid, @Param("now") Instant now);
+    int touchLastUsed(@Param("uuid") UUID uuid, @Param("now") Instant now, @Param("cutoff") Instant cutoff);
 }

--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/repository/ApiKeyRepository.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/repository/ApiKeyRepository.java
@@ -2,8 +2,13 @@ package edu.harvard.hms.dbmi.avillach.auth.repository;
 
 import edu.harvard.hms.dbmi.avillach.auth.entity.ApiKey;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -14,4 +19,11 @@ public interface ApiKeyRepository extends JpaRepository<ApiKey, UUID> {
     Optional<ApiKey> findByKeyHash(String keyHash);
 
     List<ApiKey> findAllByOrderByCreatedAtDesc();
+
+    // dedicated single-column update: a save() of the entity loaded during verification would merge
+    // every column, letting a stale revoked_at=null overwrite a concurrent revocation
+    @Modifying
+    @Transactional
+    @Query("UPDATE api_key k SET k.lastUsedAt = :now WHERE k.uuid = :uuid AND k.revokedAt IS NULL AND k.expiresAt > :now")
+    int touchLastUsed(@Param("uuid") UUID uuid, @Param("now") Instant now);
 }

--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/repository/ApiKeyRepository.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/repository/ApiKeyRepository.java
@@ -1,0 +1,17 @@
+package edu.harvard.hms.dbmi.avillach.auth.repository;
+
+import edu.harvard.hms.dbmi.avillach.auth.entity.ApiKey;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+public interface ApiKeyRepository extends JpaRepository<ApiKey, UUID> {
+
+    Optional<ApiKey> findByKeyHash(String keyHash);
+
+    List<ApiKey> findAllByOrderByCreatedAtDesc();
+}

--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/rest/ApiKeyController.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/rest/ApiKeyController.java
@@ -1,0 +1,157 @@
+package edu.harvard.hms.dbmi.avillach.auth.rest;
+
+import edu.harvard.dbmi.avillach.logging.AuditEvent;
+import edu.harvard.hms.dbmi.avillach.auth.model.request.PlatformApiKeyRequest;
+import edu.harvard.hms.dbmi.avillach.auth.model.request.UserApiKeyRequest;
+import edu.harvard.hms.dbmi.avillach.auth.model.response.ApiKeyCreationResponse;
+import edu.harvard.hms.dbmi.avillach.auth.model.response.ApiKeyMetadata;
+import edu.harvard.hms.dbmi.avillach.auth.model.response.ApiKeyPage;
+import edu.harvard.hms.dbmi.avillach.auth.model.response.PICSUREResponse;
+import edu.harvard.hms.dbmi.avillach.auth.service.CaptchaVerifier;
+import edu.harvard.hms.dbmi.avillach.auth.service.impl.ApiKeyService;
+import edu.harvard.hms.dbmi.avillach.auth.utils.AuditAttributes;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static edu.harvard.hms.dbmi.avillach.auth.utils.AuthNaming.AuthRoleNaming.ADMIN;
+import static edu.harvard.hms.dbmi.avillach.auth.utils.AuthNaming.AuthRoleNaming.SUPER_ADMIN;
+
+/**
+ * <p>Endpoints for open-access API keys. Key generation for anonymous users is public (CAPTCHA-gated);
+ * listing, platform-key minting, and revocation are admin operations.</p>
+ * <br>The plaintext key appears only in the creation response body. It is never persisted or logged.
+ */
+@Tag(name = "API Key Management")
+@Controller
+public class ApiKeyController {
+
+    private static final int MAX_METADATA_FIELD_LENGTH = 255;
+    private static final int MAX_PAGE_SIZE = 1000;
+
+    private final ApiKeyService apiKeyService;
+    private final CaptchaVerifier captchaVerifier;
+    private final boolean openIdpProviderIsEnabled;
+    private final boolean generationEnabled;
+
+    @Autowired
+    public ApiKeyController(
+        ApiKeyService apiKeyService, CaptchaVerifier captchaVerifier,
+        @Value("${open.idp.provider.is.enabled}") boolean openIdpProviderIsEnabled,
+        @Value("${api.key.generation.enabled}") boolean generationEnabled
+    ) {
+        this.apiKeyService = apiKeyService;
+        this.captchaVerifier = captchaVerifier;
+        this.openIdpProviderIsEnabled = openIdpProviderIsEnabled;
+        this.generationEnabled = generationEnabled;
+    }
+
+    @Operation(description = "Generate a USER API key for open access. Public endpoint, gated by CAPTCHA. The key is returned once and cannot be recovered.")
+    @AuditEvent(type = "ACCESS", action = "api_key.create")
+    @PostMapping(produces = "application/json", path = "/open/apiKey")
+    public ResponseEntity<?> createUserKey(
+        @Parameter(required = true, description = "captchaToken (required when CAPTCHA is enabled) and optional contact email")
+        @RequestBody UserApiKeyRequest keyRequest, HttpServletRequest request
+    ) {
+        if (!generationEnabled || !openIdpProviderIsEnabled) {
+            return PICSUREResponse.protocolError("API key generation is not enabled on this deployment.");
+        }
+        String email = blankToNull(keyRequest.email());
+        if (tooLong(email)) {
+            return PICSUREResponse.protocolError("Email must be at most " + MAX_METADATA_FIELD_LENGTH + " characters.");
+        }
+        if (!captchaVerifier.verify(keyRequest.captchaToken(), AuditAttributes.extractClientIp(request))) {
+            AuditAttributes.putMetadata(request, "captcha_result", "failure");
+            return PICSUREResponse.protocolError("CAPTCHA verification failed.");
+        }
+
+        ApiKeyCreationResponse created = apiKeyService.generateUserKey(email);
+        AuditAttributes.putMetadata(request, "api_key_id", created.uuid().toString());
+        AuditAttributes.putMetadata(request, "api_key_prefix", created.displayPrefix());
+        return PICSUREResponse.success(created);
+    }
+
+    @Operation(description = "GET a page of API key metadata (never key material), newest first, requires ADMIN or SUPER_ADMIN role")
+    @AuditEvent(type = "OTHER", action = "api_key.list")
+    @RolesAllowed({ADMIN, SUPER_ADMIN})
+    @GetMapping(produces = "application/json", path = "/apiKey")
+    public ResponseEntity<ApiKeyPage> listKeys(
+        @RequestParam(value = "page", defaultValue = "0") int page, @RequestParam(value = "size", defaultValue = "100") int size
+    ) {
+        return PICSUREResponse.success(apiKeyService.listKeys(Math.max(0, page), Math.clamp(size, 1, MAX_PAGE_SIZE)));
+    }
+
+    @Operation(description = "Mint a PLATFORM API key for a partner service, requires SUPER_ADMIN role. The key is returned once and cannot be recovered.")
+    @AuditEvent(type = "ADMIN", action = "api_key.platform.create")
+    @RolesAllowed({SUPER_ADMIN})
+    @PostMapping(produces = "application/json", path = "/apiKey/platform")
+    public ResponseEntity<?> createPlatformKey(
+        @Parameter(required = true, description = "name and contact email (both required), optional ISO-8601 expiresAt")
+        @RequestBody PlatformApiKeyRequest keyRequest, HttpServletRequest request
+    ) {
+        String name = blankToNull(keyRequest.name());
+        String email = blankToNull(keyRequest.email());
+        if (name == null || email == null) {
+            return PICSUREResponse.protocolError("Platform keys require a name and a contact email.");
+        }
+        if (tooLong(name) || tooLong(email)) {
+            return PICSUREResponse.protocolError("Name and email must be at most " + MAX_METADATA_FIELD_LENGTH + " characters.");
+        }
+
+        ApiKeyCreationResponse created;
+        try {
+            created = apiKeyService.generatePlatformKey(name, email, keyRequest.expiresAt());
+        } catch (IllegalArgumentException e) {
+            return PICSUREResponse.protocolError(e.getMessage());
+        }
+        AuditAttributes.putMetadata(request, "api_key_id", created.uuid().toString());
+        AuditAttributes.putMetadata(request, "api_key_prefix", created.displayPrefix());
+        return PICSUREResponse.success(created);
+    }
+
+    @Operation(description = "Revoke an API key by UUID, requires SUPER_ADMIN role. Revocation is permanent.")
+    @AuditEvent(type = "ADMIN", action = "api_key.revoke")
+    @RolesAllowed({SUPER_ADMIN})
+    @PutMapping(produces = "application/json", path = "/apiKey/{keyId}/revoke")
+    public ResponseEntity<?> revokeKey(
+        @Parameter(required = true, description = "UUID of the API key to revoke") @PathVariable("keyId") String keyId,
+        HttpServletRequest request
+    ) {
+        UUID uuid;
+        try {
+            uuid = UUID.fromString(keyId);
+        } catch (IllegalArgumentException e) {
+            return PICSUREResponse.protocolError("Invalid API key ID: " + keyId);
+        }
+
+        AuditAttributes.putMetadata(request, "api_key_id", keyId);
+        Optional<ApiKeyMetadata> revoked = apiKeyService.revokeKey(uuid);
+        if (revoked.isEmpty()) {
+            return PICSUREResponse.protocolError("API key not found by given ID: " + keyId);
+        }
+        return PICSUREResponse.success(revoked.get());
+    }
+
+    private static String blankToNull(String value) {
+        return value == null || value.isBlank() ? null : value.trim();
+    }
+
+    private static boolean tooLong(String value) {
+        return value != null && value.length() > MAX_METADATA_FIELD_LENGTH;
+    }
+}

--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/rest/ApiKeyController.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/rest/ApiKeyController.java
@@ -1,6 +1,7 @@
 package edu.harvard.hms.dbmi.avillach.auth.rest;
 
 import edu.harvard.dbmi.avillach.logging.AuditEvent;
+import edu.harvard.hms.dbmi.avillach.auth.enums.ApiKeyType;
 import edu.harvard.hms.dbmi.avillach.auth.model.request.PlatformApiKeyRequest;
 import edu.harvard.hms.dbmi.avillach.auth.model.request.UserApiKeyRequest;
 import edu.harvard.hms.dbmi.avillach.auth.model.response.ApiKeyCreationResponse;
@@ -87,14 +88,26 @@ public class ApiKeyController {
         return PICSUREResponse.success(created);
     }
 
-    @Operation(description = "GET a page of API key metadata (never key material), newest first, requires ADMIN or SUPER_ADMIN role")
+    @Operation(
+        description = "GET a page of API key metadata (never key material), newest first, optionally filtered by keyType, "
+            + "requires ADMIN or SUPER_ADMIN role"
+    )
     @AuditEvent(type = "OTHER", action = "api_key.list")
     @RolesAllowed({ADMIN, SUPER_ADMIN})
     @GetMapping(produces = "application/json", path = "/apiKey")
-    public ResponseEntity<ApiKeyPage> listKeys(
-        @RequestParam(value = "page", defaultValue = "0") int page, @RequestParam(value = "size", defaultValue = "100") int size
+    public ResponseEntity<?> listKeys(
+        @RequestParam(value = "page", defaultValue = "0") int page, @RequestParam(value = "size", defaultValue = "100") int size,
+        @RequestParam(value = "keyType", required = false) String keyType
     ) {
-        return PICSUREResponse.success(apiKeyService.listKeys(Math.max(0, page), Math.clamp(size, 1, MAX_PAGE_SIZE)));
+        // parse the enum here rather than binding it as a method parameter: a bad value would
+        // otherwise throw MethodArgumentTypeMismatchException, which the global handler maps to 500
+        ApiKeyType parsedType;
+        try {
+            parsedType = keyType == null || keyType.isBlank() ? null : ApiKeyType.valueOf(keyType.trim().toUpperCase());
+        } catch (IllegalArgumentException e) {
+            return PICSUREResponse.protocolError("Invalid keyType: " + keyType + ". Must be USER or PLATFORM.");
+        }
+        return PICSUREResponse.success(apiKeyService.listKeys(Math.max(0, page), Math.clamp(size, 1, MAX_PAGE_SIZE), parsedType));
     }
 
     @Operation(description = "Mint a PLATFORM API key for a partner service, requires SUPER_ADMIN role. The key is returned once and cannot be recovered.")

--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/rest/ApiKeyController.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/rest/ApiKeyController.java
@@ -72,8 +72,8 @@ public class ApiKeyController {
         if (!generationEnabled || !openIdpProviderIsEnabled) {
             return PICSUREResponse.protocolError("API key generation is not enabled on this deployment.");
         }
-        String name = blankToNull(keyRequest.name());
-        String email = blankToNull(keyRequest.email());
+        String name = normalize(keyRequest.name());
+        String email = normalize(keyRequest.email());
         if (tooLong(name) || tooLong(email)) {
             return PICSUREResponse.protocolError("Name and email must be at most " + MAX_METADATA_FIELD_LENGTH + " characters.");
         }
@@ -114,8 +114,8 @@ public class ApiKeyController {
         @Parameter(required = true, description = "name and contact email (both required), optional ISO-8601 expiresAt")
         @RequestBody PlatformApiKeyRequest keyRequest, HttpServletRequest request
     ) {
-        String name = blankToNull(keyRequest.name());
-        String email = blankToNull(keyRequest.email());
+        String name = normalize(keyRequest.name());
+        String email = normalize(keyRequest.email());
         if (name == null || email == null) {
             return PICSUREResponse.protocolError("Platform keys require a name and a contact email.");
         }
@@ -142,23 +142,29 @@ public class ApiKeyController {
         @Parameter(required = true, description = "UUID of the API key to revoke") @PathVariable("keyId") String keyId,
         HttpServletRequest request
     ) {
+        // the raw keyId is client-controlled: never echo it back or record it; the parsed UUID is canonical
         UUID uuid;
         try {
             uuid = UUID.fromString(keyId);
         } catch (IllegalArgumentException e) {
-            return PICSUREResponse.protocolError("Invalid API key ID: " + keyId);
+            return PICSUREResponse.protocolError("Invalid API key ID.");
         }
 
-        AuditAttributes.putMetadata(request, "api_key_id", keyId);
+        AuditAttributes.putMetadata(request, "api_key_id", uuid.toString());
         Optional<ApiKeyMetadata> revoked = apiKeyService.revokeKey(uuid);
         if (revoked.isEmpty()) {
-            return PICSUREResponse.protocolError("API key not found by given ID: " + keyId);
+            return PICSUREResponse.protocolError("API key not found by given ID.");
         }
         return PICSUREResponse.success(revoked.get());
     }
 
-    private static String blankToNull(String value) {
-        return value == null || value.isBlank() ? null : value.trim();
+    // strips control characters at the boundary: these free-text fields flow into audit metadata and logs
+    private static String normalize(String value) {
+        if (value == null) {
+            return null;
+        }
+        String cleaned = value.replaceAll("\\p{Cntrl}", "").trim();
+        return cleaned.isBlank() ? null : cleaned;
     }
 
     private static boolean tooLong(String value) {

--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/rest/ApiKeyController.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/rest/ApiKeyController.java
@@ -95,22 +95,18 @@ public class ApiKeyController {
     @AuditEvent(type = "OTHER", action = "api_key.list")
     @RolesAllowed({ADMIN, SUPER_ADMIN})
     @GetMapping(produces = "application/json", path = "/apiKey")
-    public ResponseEntity<?> listKeys(
+    public ResponseEntity<ApiKeyPage> listKeys(
         @RequestParam(value = "page", defaultValue = "0") int page, @RequestParam(value = "size", defaultValue = "100") int size,
-        @RequestParam(value = "keyType", required = false) String keyType
+        @RequestParam(value = "keyType", required = false) ApiKeyType keyType
     ) {
-        // parse the enum here rather than binding it as a method parameter: a bad value would
-        // otherwise throw MethodArgumentTypeMismatchException, which the global handler maps to 500
-        ApiKeyType parsedType;
-        try {
-            parsedType = keyType == null || keyType.isBlank() ? null : ApiKeyType.valueOf(keyType.trim().toUpperCase());
-        } catch (IllegalArgumentException e) {
-            return PICSUREResponse.protocolError("Invalid keyType: " + keyType + ". Must be USER or PLATFORM.");
-        }
-        return PICSUREResponse.success(apiKeyService.listKeys(Math.max(0, page), Math.clamp(size, 1, MAX_PAGE_SIZE), parsedType));
+        return PICSUREResponse.success(apiKeyService.listKeys(Math.max(0, page), Math.clamp(size, 1, MAX_PAGE_SIZE), keyType));
     }
 
-    @Operation(description = "Mint a PLATFORM API key for a partner service, requires SUPER_ADMIN role. The key is returned once and cannot be recovered.")
+    @Operation(
+        description = "Mint a PLATFORM API key for a partner service, requires SUPER_ADMIN role. Expiry: an explicit ISO-8601 expiresAt,"
+            + " or neverExpires=true (mutually exclusive), or neither for the configured platform TTL default."
+            + " The key is returned once and cannot be recovered."
+    )
     @AuditEvent(type = "ADMIN", action = "api_key.platform.create")
     @RolesAllowed({SUPER_ADMIN})
     @PostMapping(produces = "application/json", path = "/apiKey/platform")
@@ -129,7 +125,7 @@ public class ApiKeyController {
 
         ApiKeyCreationResponse created;
         try {
-            created = apiKeyService.generatePlatformKey(name, email, keyRequest.expiresAt());
+            created = apiKeyService.generatePlatformKey(name, email, keyRequest.expiresAt(), keyRequest.neverExpires());
         } catch (IllegalArgumentException e) {
             return PICSUREResponse.protocolError(e.getMessage());
         }

--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/rest/ApiKeyController.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/rest/ApiKeyController.java
@@ -65,22 +65,23 @@ public class ApiKeyController {
     @AuditEvent(type = "ACCESS", action = "api_key.create")
     @PostMapping(produces = "application/json", path = "/open/apiKey")
     public ResponseEntity<?> createUserKey(
-        @Parameter(required = true, description = "captchaToken (required when CAPTCHA is enabled) and optional contact email")
+        @Parameter(required = true, description = "captchaToken (required when CAPTCHA is enabled) and optional contact name/email")
         @RequestBody UserApiKeyRequest keyRequest, HttpServletRequest request
     ) {
         if (!generationEnabled || !openIdpProviderIsEnabled) {
             return PICSUREResponse.protocolError("API key generation is not enabled on this deployment.");
         }
+        String name = blankToNull(keyRequest.name());
         String email = blankToNull(keyRequest.email());
-        if (tooLong(email)) {
-            return PICSUREResponse.protocolError("Email must be at most " + MAX_METADATA_FIELD_LENGTH + " characters.");
+        if (tooLong(name) || tooLong(email)) {
+            return PICSUREResponse.protocolError("Name and email must be at most " + MAX_METADATA_FIELD_LENGTH + " characters.");
         }
         if (!captchaVerifier.verify(keyRequest.captchaToken(), AuditAttributes.extractClientIp(request))) {
             AuditAttributes.putMetadata(request, "captcha_result", "failure");
             return PICSUREResponse.protocolError("CAPTCHA verification failed.");
         }
 
-        ApiKeyCreationResponse created = apiKeyService.generateUserKey(email);
+        ApiKeyCreationResponse created = apiKeyService.generateUserKey(name, email);
         AuditAttributes.putMetadata(request, "api_key_id", created.uuid().toString());
         AuditAttributes.putMetadata(request, "api_key_prefix", created.displayPrefix());
         return PICSUREResponse.success(created);

--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/CaptchaVerifier.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/CaptchaVerifier.java
@@ -1,0 +1,11 @@
+package edu.harvard.hms.dbmi.avillach.auth.service;
+
+/**
+ * Verifies a CAPTCHA challenge response before a self-service API key is minted. Implementations
+ * are selected by the {@code captcha.provider} property; deployments without egress (or local dev)
+ * use the disabled implementation, which accepts everything.
+ */
+public interface CaptchaVerifier {
+
+    boolean verify(String captchaToken, String remoteIp);
+}

--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/ApiKeyService.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/ApiKeyService.java
@@ -1,0 +1,215 @@
+package edu.harvard.hms.dbmi.avillach.auth.service.impl;
+
+import edu.harvard.hms.dbmi.avillach.auth.entity.ApiKey;
+import edu.harvard.hms.dbmi.avillach.auth.enums.ApiKeyType;
+import edu.harvard.hms.dbmi.avillach.auth.model.response.ApiKeyCreationResponse;
+import edu.harvard.hms.dbmi.avillach.auth.model.response.ApiKeyMetadata;
+import edu.harvard.hms.dbmi.avillach.auth.repository.ApiKeyRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HexFormat;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Generates, verifies, and manages API keys for open-access requests. Only a hash of each key is
+ * stored; the plaintext exists solely in the {@link ApiKeyCreationResponse} returned at creation.
+ */
+@Service
+public class ApiKeyService {
+
+    private static final Logger logger = LoggerFactory.getLogger(ApiKeyService.class);
+
+    public static final String KEY_PREFIX = "picsure_";
+    public static final String SCHEME_SHA256 = "SHA256";
+    public static final String SCHEME_HMAC_SHA256 = "HMAC_SHA256";
+
+    private static final SecureRandom SECURE_RANDOM = new SecureRandom();
+    private static final String BASE62_ALPHABET = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+    // 43 base62 characters carry just under 256 bits of entropy
+    private static final int KEY_BODY_LENGTH = 43;
+    private static final int DISPLAY_PREFIX_LENGTH = 8;
+    private static final Duration LAST_USED_WRITE_INTERVAL = Duration.ofMinutes(1);
+
+    private final ApiKeyRepository apiKeyRepository;
+    private final String pepper;
+    private final List<String> previousPeppers;
+    private final long userKeyTtlDays;
+
+    @Autowired
+    public ApiKeyService(
+        ApiKeyRepository apiKeyRepository, @Value("${api.key.pepper}") String pepper,
+        @Value("${api.key.pepper.previous}") String previousPeppers, @Value("${api.key.user.ttl.days}") long userKeyTtlDays
+    ) {
+        if (userKeyTtlDays <= 0) {
+            throw new IllegalStateException("api.key.user.ttl.days must be positive, was " + userKeyTtlDays);
+        }
+        this.apiKeyRepository = apiKeyRepository;
+        this.pepper = pepper;
+        this.previousPeppers = previousPeppers == null ? List.of()
+            : Arrays.stream(previousPeppers.split(",")).map(String::trim).filter(ApiKeyService::isSet).toList();
+        this.userKeyTtlDays = userKeyTtlDays;
+    }
+
+    public ApiKeyCreationResponse generateUserKey(String email) {
+        return generate(ApiKeyType.USER, null, email, null);
+    }
+
+    public ApiKeyCreationResponse generatePlatformKey(String name, String email, Instant expiresAt) {
+        return generate(ApiKeyType.PLATFORM, name, email, expiresAt);
+    }
+
+    private ApiKeyCreationResponse generate(ApiKeyType keyType, String name, String email, Instant expiresAt) {
+        Instant createdAt = Instant.now();
+        if (expiresAt == null) {
+            expiresAt = createdAt.plus(userKeyTtlDays, ChronoUnit.DAYS);
+        }
+        if (!expiresAt.isAfter(createdAt)) {
+            throw new IllegalArgumentException("API key expiration must be in the future");
+        }
+        String body = randomBase62(KEY_BODY_LENGTH);
+        String plaintext = KEY_PREFIX + body;
+        ApiKey apiKey = new ApiKey().setKeyHash(hashWithCurrentScheme(plaintext)).setHashScheme(currentScheme())
+            .setDisplayPrefix(body.substring(0, DISPLAY_PREFIX_LENGTH)).setKeyType(keyType).setName(name).setEmail(email)
+            .setCreatedAt(createdAt).setExpiresAt(expiresAt);
+        apiKey = apiKeyRepository.save(apiKey);
+        logger.info("Generated {} API key {} with display prefix {}", keyType, apiKey.getUuid(), apiKey.getDisplayPrefix());
+        return new ApiKeyCreationResponse(plaintext, apiKey.getUuid(), apiKey.getDisplayPrefix(), keyType, expiresAt);
+    }
+
+    /**
+     * Verifies a presented key: indexed hash lookup, then revocation and expiry checks.
+     * Returns the matching entity only when the key is currently valid.
+     */
+    public Optional<ApiKey> verifyKey(String plaintext) {
+        if (plaintext == null || !plaintext.startsWith(KEY_PREFIX)) {
+            return Optional.empty();
+        }
+
+        Optional<ApiKey> found = findUnderAnyActiveScheme(plaintext);
+        if (found.isEmpty()) {
+            return Optional.empty();
+        }
+
+        ApiKey apiKey = found.get();
+        Instant now = Instant.now();
+        if (apiKey.getRevokedAt() != null || !now.isBefore(apiKey.getExpiresAt())) {
+            logger.info(
+                "Rejected {} API key with display prefix {}: {}", apiKey.getKeyType(), apiKey.getDisplayPrefix(),
+                apiKey.getRevokedAt() != null ? "revoked" : "expired"
+            );
+            return Optional.empty();
+        }
+
+        touchLastUsed(apiKey, now);
+        return Optional.of(apiKey);
+    }
+
+    public List<ApiKeyMetadata> listKeys() {
+        return apiKeyRepository.findAllByOrderByCreatedAtDesc().stream().map(ApiKeyMetadata::from).toList();
+    }
+
+    public Optional<ApiKeyMetadata> revokeKey(UUID uuid) {
+        return apiKeyRepository.findById(uuid).map(apiKey -> {
+            if (apiKey.getRevokedAt() == null) {
+                apiKey.setRevokedAt(Instant.now());
+                apiKey = apiKeyRepository.save(apiKey);
+                logger.info("Revoked API key {} with display prefix {}", apiKey.getUuid(), apiKey.getDisplayPrefix());
+            }
+            return ApiKeyMetadata.from(apiKey);
+        });
+    }
+
+    /**
+     * Tries the current pepper, then each previous pepper (covering rotation, oldest keys last),
+     * then the unpeppered scheme (covering keys minted before a pepper was configured). Unset
+     * peppers are skipped, so HMAC-backed keys still verify while the current pepper is
+     * accidentally omitted, as long as it appears in the previous-pepper list.
+     */
+    private Optional<ApiKey> findUnderAnyActiveScheme(String plaintext) {
+        List<String> activePeppers = new ArrayList<>();
+        if (hasPepper()) {
+            activePeppers.add(pepper);
+        }
+        activePeppers.addAll(previousPeppers);
+        for (String activePepper : activePeppers) {
+            Optional<ApiKey> found = apiKeyRepository.findByKeyHash(hmacSha256(activePepper, plaintext))
+                .filter(key -> SCHEME_HMAC_SHA256.equals(key.getHashScheme()));
+            if (found.isPresent()) {
+                return found;
+            }
+        }
+        return apiKeyRepository.findByKeyHash(sha256(plaintext)).filter(key -> SCHEME_SHA256.equals(key.getHashScheme()));
+    }
+
+    // last_used_at is usage telemetry, not an audit trail; throttling avoids a DB write per request
+    // and a failed write must not reject an otherwise valid key
+    private void touchLastUsed(ApiKey apiKey, Instant now) {
+        if (apiKey.getLastUsedAt() == null || apiKey.getLastUsedAt().isBefore(now.minus(LAST_USED_WRITE_INTERVAL))) {
+            try {
+                apiKeyRepository.touchLastUsed(apiKey.getUuid(), now);
+            } catch (RuntimeException e) {
+                logger.warn("Failed to update last_used_at for API key with display prefix {}", apiKey.getDisplayPrefix(), e);
+            }
+        }
+    }
+
+    private boolean hasPepper() {
+        return isSet(pepper);
+    }
+
+    private static boolean isSet(String value) {
+        return value != null && !value.isBlank();
+    }
+
+    private String currentScheme() {
+        return hasPepper() ? SCHEME_HMAC_SHA256 : SCHEME_SHA256;
+    }
+
+    private String hashWithCurrentScheme(String plaintext) {
+        return hasPepper() ? hmacSha256(pepper, plaintext) : sha256(plaintext);
+    }
+
+    private static String sha256(String plaintext) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            return HexFormat.of().formatHex(digest.digest(plaintext.getBytes(StandardCharsets.UTF_8)));
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 unavailable", e);
+        }
+    }
+
+    private static String hmacSha256(String pepper, String plaintext) {
+        try {
+            Mac mac = Mac.getInstance("HmacSHA256");
+            mac.init(new SecretKeySpec(pepper.getBytes(StandardCharsets.UTF_8), "HmacSHA256"));
+            return HexFormat.of().formatHex(mac.doFinal(plaintext.getBytes(StandardCharsets.UTF_8)));
+        } catch (Exception e) {
+            throw new IllegalStateException("HmacSHA256 unavailable", e);
+        }
+    }
+
+    private static String randomBase62(int length) {
+        StringBuilder builder = new StringBuilder(length);
+        for (int i = 0; i < length; i++) {
+            builder.append(BASE62_ALPHABET.charAt(SECURE_RANDOM.nextInt(BASE62_ALPHABET.length())));
+        }
+        return builder.toString();
+    }
+}

--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/ApiKeyService.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/ApiKeyService.java
@@ -55,37 +55,53 @@ public class ApiKeyService {
     private final String pepper;
     private final List<String> previousPeppers;
     private final long userKeyTtlDays;
+    private final long platformKeyTtlDays;
 
     @Autowired
     public ApiKeyService(
         ApiKeyRepository apiKeyRepository, @Value("${api.key.pepper}") String pepper,
-        @Value("${api.key.pepper.previous}") String previousPeppers, @Value("${api.key.user.ttl.days}") long userKeyTtlDays
+        @Value("${api.key.pepper.previous}") String previousPeppers, @Value("${api.key.user.ttl.days}") long userKeyTtlDays,
+        @Value("${api.key.platform.ttl.days}") long platformKeyTtlDays
     ) {
         if (userKeyTtlDays <= 0) {
             throw new IllegalStateException("api.key.user.ttl.days must be positive, was " + userKeyTtlDays);
+        }
+        if (platformKeyTtlDays <= 0) {
+            throw new IllegalStateException("api.key.platform.ttl.days must be positive, was " + platformKeyTtlDays);
         }
         this.apiKeyRepository = apiKeyRepository;
         this.pepper = pepper;
         this.previousPeppers = previousPeppers == null ? List.of()
             : Arrays.stream(previousPeppers.split(",")).map(String::trim).filter(ApiKeyService::isSet).toList();
         this.userKeyTtlDays = userKeyTtlDays;
+        this.platformKeyTtlDays = platformKeyTtlDays;
     }
 
     public ApiKeyCreationResponse generateUserKey(String name, String email) {
-        return generate(ApiKeyType.USER, name, email, null);
+        return generate(ApiKeyType.USER, name, email, null, false);
     }
 
-    public ApiKeyCreationResponse generatePlatformKey(String name, String email, Instant expiresAt) {
-        return generate(ApiKeyType.PLATFORM, name, email, expiresAt);
+    /**
+     * @param expiresAt explicit expiry, or null to apply the platform TTL default
+     * @param neverExpires mint a non-expiring key; mutually exclusive with {@code expiresAt}
+     */
+    public ApiKeyCreationResponse generatePlatformKey(String name, String email, Instant expiresAt, boolean neverExpires) {
+        return generate(ApiKeyType.PLATFORM, name, email, expiresAt, neverExpires);
     }
 
-    private ApiKeyCreationResponse generate(ApiKeyType keyType, String name, String email, Instant expiresAt) {
+    private ApiKeyCreationResponse generate(ApiKeyType keyType, String name, String email, Instant expiresAt, boolean neverExpires) {
         Instant createdAt = Instant.now();
-        if (expiresAt == null) {
-            expiresAt = createdAt.plus(userKeyTtlDays, ChronoUnit.DAYS);
+        if (neverExpires && expiresAt != null) {
+            throw new IllegalArgumentException("neverExpires and expiresAt are mutually exclusive");
         }
-        if (!expiresAt.isAfter(createdAt)) {
-            throw new IllegalArgumentException("API key expiration must be in the future");
+        if (!neverExpires) {
+            if (expiresAt == null) {
+                long ttlDays = keyType == ApiKeyType.PLATFORM ? platformKeyTtlDays : userKeyTtlDays;
+                expiresAt = createdAt.plus(ttlDays, ChronoUnit.DAYS);
+            }
+            if (!expiresAt.isAfter(createdAt)) {
+                throw new IllegalArgumentException("API key expiration must be in the future");
+            }
         }
         String body = randomBase62(KEY_BODY_LENGTH);
         String plaintext = KEY_PREFIX + body;
@@ -112,7 +128,7 @@ public class ApiKeyService {
 
         ApiKey apiKey = found.get();
         Instant now = Instant.now();
-        if (apiKey.getRevokedAt() != null || !now.isBefore(apiKey.getExpiresAt())) {
+        if (apiKey.getRevokedAt() != null || isExpired(apiKey, now)) {
             logger.info(
                 "Rejected {} API key with display prefix {}: {}", apiKey.getKeyType(), apiKey.getDisplayPrefix(),
                 apiKey.getRevokedAt() != null ? "revoked" : "expired"
@@ -174,6 +190,11 @@ public class ApiKeyService {
                 logger.warn("Failed to update last_used_at for API key with display prefix {}", apiKey.getDisplayPrefix(), e);
             }
         }
+    }
+
+    // null expires_at means the key never expires (explicit choice at platform-key mint time)
+    private static boolean isExpired(ApiKey apiKey, Instant now) {
+        return apiKey.getExpiresAt() != null && !now.isBefore(apiKey.getExpiresAt());
     }
 
     private boolean hasPepper() {

--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/ApiKeyService.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/ApiKeyService.java
@@ -181,11 +181,13 @@ public class ApiKeyService {
     }
 
     // last_used_at is usage telemetry, not an audit trail; throttling avoids a DB write per request
-    // and a failed write must not reject an otherwise valid key
+    // and a failed write must not reject an otherwise valid key. The in-memory check is only a fast
+    // path — the cutoff in the UPDATE is what makes the throttle hold under concurrency
     private void touchLastUsed(ApiKey apiKey, Instant now) {
-        if (apiKey.getLastUsedAt() == null || apiKey.getLastUsedAt().isBefore(now.minus(LAST_USED_WRITE_INTERVAL))) {
+        Instant cutoff = now.minus(LAST_USED_WRITE_INTERVAL);
+        if (apiKey.getLastUsedAt() == null || apiKey.getLastUsedAt().isBefore(cutoff)) {
             try {
-                apiKeyRepository.touchLastUsed(apiKey.getUuid(), now);
+                apiKeyRepository.touchLastUsed(apiKey.getUuid(), now, cutoff);
             } catch (RuntimeException e) {
                 logger.warn("Failed to update last_used_at for API key with display prefix {}", apiKey.getDisplayPrefix(), e);
             }

--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/ApiKeyService.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/ApiKeyService.java
@@ -124,8 +124,10 @@ public class ApiKeyService {
         return Optional.of(apiKey);
     }
 
-    public ApiKeyPage listKeys(int page, int size) {
-        Page<ApiKey> keys = apiKeyRepository.findAll(PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt")));
+    public ApiKeyPage listKeys(int page, int size, ApiKeyType keyType) {
+        PageRequest pageRequest = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
+        Page<ApiKey> keys = keyType == null ? apiKeyRepository.findAll(pageRequest)
+            : apiKeyRepository.findByKeyType(keyType, pageRequest);
         return new ApiKeyPage(keys.getContent().stream().map(ApiKeyMetadata::from).toList(), keys.getTotalElements(), page, size);
     }
 

--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/ApiKeyService.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/ApiKeyService.java
@@ -194,8 +194,14 @@ public class ApiKeyService {
         }
     }
 
+    // null expiry means "never expires", an opt-in that exists only for PLATFORM keys. The DB CHECK
+    // enforces that too, but parallel deployment schemas are written separately — fail closed here
+    // in case one of them misses the constraint
     private static boolean isExpired(ApiKey apiKey, Instant now) {
-        return apiKey.getExpiresAt() != null && !now.isBefore(apiKey.getExpiresAt());
+        if (apiKey.getExpiresAt() == null) {
+            return apiKey.getKeyType() != ApiKeyType.PLATFORM;
+        }
+        return !now.isBefore(apiKey.getExpiresAt());
     }
 
     private boolean hasPepper() {

--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/ApiKeyService.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/ApiKeyService.java
@@ -4,11 +4,15 @@ import edu.harvard.hms.dbmi.avillach.auth.entity.ApiKey;
 import edu.harvard.hms.dbmi.avillach.auth.enums.ApiKeyType;
 import edu.harvard.hms.dbmi.avillach.auth.model.response.ApiKeyCreationResponse;
 import edu.harvard.hms.dbmi.avillach.auth.model.response.ApiKeyMetadata;
+import edu.harvard.hms.dbmi.avillach.auth.model.response.ApiKeyPage;
 import edu.harvard.hms.dbmi.avillach.auth.repository.ApiKeyRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
 import javax.crypto.Mac;
@@ -94,8 +98,7 @@ public class ApiKeyService {
     }
 
     /**
-     * Verifies a presented key: indexed hash lookup, then revocation and expiry checks.
-     * Returns the matching entity only when the key is currently valid.
+     * Returns the matching key only when it is currently valid: known, unrevoked, unexpired.
      */
     public Optional<ApiKey> verifyKey(String plaintext) {
         if (plaintext == null || !plaintext.startsWith(KEY_PREFIX)) {
@@ -121,8 +124,9 @@ public class ApiKeyService {
         return Optional.of(apiKey);
     }
 
-    public List<ApiKeyMetadata> listKeys() {
-        return apiKeyRepository.findAllByOrderByCreatedAtDesc().stream().map(ApiKeyMetadata::from).toList();
+    public ApiKeyPage listKeys(int page, int size) {
+        Page<ApiKey> keys = apiKeyRepository.findAll(PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt")));
+        return new ApiKeyPage(keys.getContent().stream().map(ApiKeyMetadata::from).toList(), keys.getTotalElements(), page, size);
     }
 
     public Optional<ApiKeyMetadata> revokeKey(UUID uuid) {

--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/ApiKeyService.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/ApiKeyService.java
@@ -194,7 +194,6 @@ public class ApiKeyService {
         }
     }
 
-    // null expires_at means the key never expires (explicit choice at platform-key mint time)
     private static boolean isExpired(ApiKey apiKey, Instant now) {
         return apiKey.getExpiresAt() != null && !now.isBefore(apiKey.getExpiresAt());
     }

--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/ApiKeyService.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/ApiKeyService.java
@@ -71,8 +71,8 @@ public class ApiKeyService {
         this.userKeyTtlDays = userKeyTtlDays;
     }
 
-    public ApiKeyCreationResponse generateUserKey(String email) {
-        return generate(ApiKeyType.USER, null, email, null);
+    public ApiKeyCreationResponse generateUserKey(String name, String email) {
+        return generate(ApiKeyType.USER, name, email, null);
     }
 
     public ApiKeyCreationResponse generatePlatformKey(String name, String email, Instant expiresAt) {

--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/authorization/AuthorizationService.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/authorization/AuthorizationService.java
@@ -8,6 +8,7 @@ import edu.harvard.hms.dbmi.avillach.auth.model.EvaluateAccessRuleResult;
 import edu.harvard.hms.dbmi.avillach.auth.repository.UserConsentsRepository;
 import edu.harvard.hms.dbmi.avillach.auth.rest.TokenController;
 import edu.harvard.hms.dbmi.avillach.auth.service.impl.AccessRuleService;
+import edu.harvard.hms.dbmi.avillach.auth.service.impl.ApiKeyService;
 import edu.harvard.hms.dbmi.avillach.auth.service.impl.RoleService;
 import edu.harvard.hms.dbmi.avillach.auth.service.impl.SessionService;
 import edu.harvard.hms.dbmi.avillach.hpds.data.query.v3.Query;
@@ -72,13 +73,18 @@ public class AuthorizationService {
 
     private final UserConsentsRepository userConsentsRepository;
 
+    private final ApiKeyService apiKeyService;
+    private final boolean apiKeyEnforcementEnabled;
+
     @Autowired
     public AuthorizationService(AccessRuleService accessRuleService,
                                 SessionService sessionService,
                                 RoleService roleService,
                                 ConsentBasedAccessRuleEvaluator consentBasedAccessRuleEvaluator,
                                 @Value("${strict.authorization.applications.connections}") String strictConnections,
-                                UserConsentsRepository userConsentsRepository) {
+                                UserConsentsRepository userConsentsRepository,
+                                ApiKeyService apiKeyService,
+                                @Value("${api.key.enforcement.enabled}") boolean apiKeyEnforcementEnabled) {
         this.accessRuleService = accessRuleService;
         this.sessionService = sessionService;
         this.roleService = roleService;
@@ -87,6 +93,8 @@ public class AuthorizationService {
             this.strictConnections.addAll(Arrays.asList(strictConnections.split(",")));
         }
         this.userConsentsRepository = userConsentsRepository;
+        this.apiKeyService = apiKeyService;
+        this.apiKeyEnforcementEnabled = apiKeyEnforcementEnabled;
     }
 
     /**
@@ -303,6 +311,12 @@ public class AuthorizationService {
 
     public boolean openAccessRequestIsValid(Map<String, Object> inputMap) {
 
+        // the API key gate runs before the permissive early-returns below: with enforcement on,
+        // even body-less requests must present a valid key
+        if (apiKeyEnforcementEnabled && !openAccessApiKeyIsValid(inputMap)) {
+            return false;
+        }
+
         if (inputMap == null || inputMap.isEmpty()) {
             logger.info("ACCESS_LOG ___ AN OPEN ACCESS USER ___ has been denied access to application ___ NO REQUEST BODY FORWARDED BY APPLICATION");
             return true;
@@ -341,5 +355,14 @@ public class AuthorizationService {
         }
 
         return result;
+    }
+
+    private boolean openAccessApiKeyIsValid(Map<String, Object> inputMap) {
+        Object apiKey = inputMap == null ? null : inputMap.get("apiKey");
+        boolean valid = apiKey instanceof String plaintext && apiKeyService.verifyKey(plaintext).isPresent();
+        if (!valid) {
+            logger.info("ACCESS_LOG ___ AN OPEN ACCESS USER ___ has been denied access to application ___ MISSING OR INVALID API KEY");
+        }
+        return valid;
     }
 }

--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/captcha/DisabledCaptchaVerifier.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/captcha/DisabledCaptchaVerifier.java
@@ -1,0 +1,25 @@
+package edu.harvard.hms.dbmi.avillach.auth.service.impl.captcha;
+
+import edu.harvard.hms.dbmi.avillach.auth.service.CaptchaVerifier;
+import jakarta.annotation.PostConstruct;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Service;
+
+@Service
+@ConditionalOnProperty(name = "captcha.provider", havingValue = "disabled", matchIfMissing = true)
+public class DisabledCaptchaVerifier implements CaptchaVerifier {
+
+    private static final Logger logger = LoggerFactory.getLogger(DisabledCaptchaVerifier.class);
+
+    @PostConstruct
+    public void warnDisabled() {
+        logger.warn("CAPTCHA verification is DISABLED - API key generation is not gated against automated key farming");
+    }
+
+    @Override
+    public boolean verify(String captchaToken, String remoteIp) {
+        return true;
+    }
+}

--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/captcha/DisabledCaptchaVerifier.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/captcha/DisabledCaptchaVerifier.java
@@ -4,6 +4,7 @@ import edu.harvard.hms.dbmi.avillach.auth.service.CaptchaVerifier;
 import jakarta.annotation.PostConstruct;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Service;
 
@@ -13,8 +14,27 @@ public class DisabledCaptchaVerifier implements CaptchaVerifier {
 
     private static final Logger logger = LoggerFactory.getLogger(DisabledCaptchaVerifier.class);
 
+    private final boolean generationEnabled;
+    private final boolean allowUngatedGeneration;
+
+    public DisabledCaptchaVerifier(
+        @Value("${api.key.generation.enabled}") boolean generationEnabled,
+        @Value("${api.key.allow.ungated.generation}") boolean allowUngatedGeneration
+    ) {
+        this.generationEnabled = generationEnabled;
+        this.allowUngatedGeneration = allowUngatedGeneration;
+    }
+
+    // fail closed: the public generation endpoint must not silently run ungated because no
+    // CAPTCHA provider happens to be configured
     @PostConstruct
-    public void warnDisabled() {
+    public void enforceExplicitOptIn() {
+        if (generationEnabled && !allowUngatedGeneration) {
+            throw new IllegalStateException(
+                "api.key.generation.enabled is true but no CAPTCHA provider is configured. Configure captcha.provider,"
+                    + " or explicitly accept ungated anonymous key minting with api.key.allow.ungated.generation=true."
+            );
+        }
         logger.warn("CAPTCHA verification is DISABLED - API key generation is not gated against automated key farming");
     }
 

--- a/pic-sure-auth-services/src/main/resources/application.properties
+++ b/pic-sure-auth-services/src/main/resources/application.properties
@@ -102,10 +102,16 @@ open.idp.provider.is.enabled=${OPEN_IDP_PROVIDER_IS_ENABLED:false}
 
 # Open access API key configurations
 api.key.enforcement.enabled=${API_KEY_ENFORCEMENT_ENABLED:false}
+# Explicit opt-in for the public self-service key generation endpoint; keep false until the
+# deployment has an abuse gate (CAPTCHA) or accepts ungated anonymous key minting
+api.key.generation.enabled=${API_KEY_GENERATION_ENABLED:false}
 api.key.user.ttl.days=${API_KEY_USER_TTL_DAYS:90}
 api.key.pepper=${API_KEY_PEPPER:}
 # When rotating the pepper, move the old value here (comma-separated, newest first) so existing HMAC-backed keys keep verifying
 api.key.pepper.previous=${API_KEY_PEPPER_PREVIOUS:}
+# CAPTCHA gating for self-service key generation. Only 'disabled' is implemented; setting any other
+# value (e.g. 'turnstile', pending implementation) leaves no CaptchaVerifier bean and FAILS STARTUP
+captcha.provider=${CAPTCHA_PROVIDER:disabled}
 
 # OKTA configurations
 a4.okta.idp.provider.is.enabled=${A4_OKTA_IDP_PROVIDER_IS_ENABLED:false}

--- a/pic-sure-auth-services/src/main/resources/application.properties
+++ b/pic-sure-auth-services/src/main/resources/application.properties
@@ -106,6 +106,8 @@ api.key.enforcement.enabled=${API_KEY_ENFORCEMENT_ENABLED:false}
 # deployment has an abuse gate (CAPTCHA) or accepts ungated anonymous key minting
 api.key.generation.enabled=${API_KEY_GENERATION_ENABLED:false}
 api.key.user.ttl.days=${API_KEY_USER_TTL_DAYS:90}
+# Applied to platform keys minted without an explicit expiresAt; "never expires" requires the explicit neverExpires flag
+api.key.platform.ttl.days=${API_KEY_PLATFORM_TTL_DAYS:365}
 api.key.pepper=${API_KEY_PEPPER:}
 # When rotating the pepper, move the old value here (comma-separated, newest first) so existing HMAC-backed keys keep verifying
 api.key.pepper.previous=${API_KEY_PEPPER_PREVIOUS:}

--- a/pic-sure-auth-services/src/main/resources/application.properties
+++ b/pic-sure-auth-services/src/main/resources/application.properties
@@ -105,6 +105,9 @@ api.key.enforcement.enabled=${API_KEY_ENFORCEMENT_ENABLED:false}
 # Explicit opt-in for the public self-service key generation endpoint; keep false until the
 # deployment has an abuse gate (CAPTCHA) or accepts ungated anonymous key minting
 api.key.generation.enabled=${API_KEY_GENERATION_ENABLED:false}
+# Explicit unsafe opt-in: allow generation while captcha.provider=disabled. Without it, enabling
+# generation with CAPTCHA disabled fails startup instead of silently running ungated
+api.key.allow.ungated.generation=${API_KEY_ALLOW_UNGATED_GENERATION:false}
 api.key.user.ttl.days=${API_KEY_USER_TTL_DAYS:90}
 # Applied to platform keys minted without an explicit expiresAt; "never expires" requires the explicit neverExpires flag
 api.key.platform.ttl.days=${API_KEY_PLATFORM_TTL_DAYS:365}

--- a/pic-sure-auth-services/src/main/resources/application.properties
+++ b/pic-sure-auth-services/src/main/resources/application.properties
@@ -100,6 +100,13 @@ application.long.term.token.expiration.time=${LONG_TERM_TOKEN_EXPIRATION_TIME:25
 # Open IDP configurations
 open.idp.provider.is.enabled=${OPEN_IDP_PROVIDER_IS_ENABLED:false}
 
+# Open access API key configurations
+api.key.enforcement.enabled=${API_KEY_ENFORCEMENT_ENABLED:false}
+api.key.user.ttl.days=${API_KEY_USER_TTL_DAYS:90}
+api.key.pepper=${API_KEY_PEPPER:}
+# When rotating the pepper, move the old value here (comma-separated, newest first) so existing HMAC-backed keys keep verifying
+api.key.pepper.previous=${API_KEY_PEPPER_PREVIOUS:}
+
 # OKTA configurations
 a4.okta.idp.provider.is.enabled=${A4_OKTA_IDP_PROVIDER_IS_ENABLED:false}
 a4.okta.client.id=${A4_OKTA_CLIENT_ID:false}

--- a/pic-sure-auth-services/src/test/java/edu/harvard/hms/dbmi/avillach/auth/config/ApplicationConfigObjectMapperTest.java
+++ b/pic-sure-auth-services/src/test/java/edu/harvard/hms/dbmi/avillach/auth/config/ApplicationConfigObjectMapperTest.java
@@ -1,0 +1,58 @@
+package edu.harvard.hms.dbmi.avillach.auth.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import edu.harvard.hms.dbmi.avillach.auth.enums.ApiKeyType;
+import edu.harvard.hms.dbmi.avillach.auth.model.request.PlatformApiKeyRequest;
+import edu.harvard.hms.dbmi.avillach.auth.model.response.ApiKeyCreationResponse;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.Date;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * The app-defined ObjectMapper bean replaces Boot's auto-configured one, so java.time support has
+ * to be registered by hand. These tests pin the wire contract of the API-key DTOs (the first PSAMA
+ * payloads using Instant) and the legacy epoch-millis rendering of java.util.Date.
+ */
+public class ApplicationConfigObjectMapperTest {
+
+    private final ObjectMapper objectMapper = new ApplicationConfig(null).objectMapper();
+
+    @Test
+    public void testCreationResponseSerializesWithIsoInstant() throws Exception {
+        Instant expiresAt = Instant.parse("2026-10-11T12:13:14Z");
+        ApiKeyCreationResponse response = new ApiKeyCreationResponse(
+            "picsure_0000000000000000000000000000000000000000000", UUID.randomUUID(), "00000000", ApiKeyType.USER, expiresAt
+        );
+
+        String json = objectMapper.writeValueAsString(response);
+
+        assertTrue(json.contains("\"2026-10-11T12:13:14Z\""), json);
+        assertTrue(json.contains("picsure_"), json);
+    }
+
+    @Test
+    public void testPlatformRequestDeserializesIsoInstant() throws Exception {
+        PlatformApiKeyRequest request = objectMapper
+            .readValue("{\"name\":\"Partner\",\"email\":\"a@b.com\",\"expiresAt\":\"2027-01-01T00:00:00Z\"}", PlatformApiKeyRequest.class);
+
+        assertEquals(Instant.parse("2027-01-01T00:00:00Z"), request.expiresAt());
+
+        PlatformApiKeyRequest withoutExpiry =
+            objectMapper.readValue("{\"name\":\"Partner\",\"email\":\"a@b.com\"}", PlatformApiKeyRequest.class);
+        assertNull(withoutExpiry.expiresAt());
+    }
+
+    @Test
+    public void testLegacyDateStillSerializesAsEpochMillis() throws Exception {
+        record LegacyPayload(Date dateUpdated) {
+        }
+
+        String json = objectMapper.writeValueAsString(new LegacyPayload(new Date(1234567890123L)));
+
+        assertEquals("{\"dateUpdated\":1234567890123}", json);
+    }
+}

--- a/pic-sure-auth-services/src/test/java/edu/harvard/hms/dbmi/avillach/auth/exceptions/GlobalExceptionHandlerTest.java
+++ b/pic-sure-auth-services/src/test/java/edu/harvard/hms/dbmi/avillach/auth/exceptions/GlobalExceptionHandlerTest.java
@@ -3,6 +3,8 @@ package edu.harvard.hms.dbmi.avillach.auth.exceptions;
 import edu.harvard.hms.dbmi.avillach.auth.enums.ApiKeyType;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.mock.http.MockHttpInputMessage;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -35,6 +37,17 @@ public class GlobalExceptionHandlerTest {
         assertTrue(body.contains("PLATFORM"));
         // the offending value is client-controlled and must not be reflected
         assertFalse(body.contains("not-a-type"));
+    }
+
+    @Test
+    public void testUnreadableBodyIs400WithoutParserDetails() {
+        HttpMessageNotReadableException ex =
+            new HttpMessageNotReadableException("JSON parse error: raw-client-payload", new MockHttpInputMessage(new byte[0]));
+
+        ResponseEntity<?> response = handler.handleUnreadableBody(ex);
+
+        assertEquals(400, response.getStatusCode().value());
+        assertFalse(String.valueOf(response.getBody()).contains("raw-client-payload"));
     }
 
     @Test

--- a/pic-sure-auth-services/src/test/java/edu/harvard/hms/dbmi/avillach/auth/exceptions/GlobalExceptionHandlerTest.java
+++ b/pic-sure-auth-services/src/test/java/edu/harvard/hms/dbmi/avillach/auth/exceptions/GlobalExceptionHandlerTest.java
@@ -1,0 +1,49 @@
+package edu.harvard.hms.dbmi.avillach.auth.exceptions;
+
+import edu.harvard.hms.dbmi.avillach.auth.enums.ApiKeyType;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class GlobalExceptionHandlerTest {
+
+    private final GlobalExceptionHandler handler = new GlobalExceptionHandler();
+
+    @Test
+    public void testTypeMismatchIs400NotServerError() {
+        MethodArgumentTypeMismatchException ex =
+            new MethodArgumentTypeMismatchException("not-a-type", ApiKeyType.class, "keyType", null, null);
+
+        ResponseEntity<?> response = handler.handleTypeMismatch(ex);
+
+        assertEquals(400, response.getStatusCode().value());
+    }
+
+    @Test
+    public void testTypeMismatchNamesParameterAndEnumConstantsWithoutEchoingValue() {
+        MethodArgumentTypeMismatchException ex =
+            new MethodArgumentTypeMismatchException("not-a-type", ApiKeyType.class, "keyType", null, null);
+
+        String body = String.valueOf(handler.handleTypeMismatch(ex).getBody());
+
+        assertTrue(body.contains("keyType"));
+        assertTrue(body.contains("USER"));
+        assertTrue(body.contains("PLATFORM"));
+        // the offending value is client-controlled and must not be reflected
+        assertFalse(body.contains("not-a-type"));
+    }
+
+    @Test
+    public void testTypeMismatchOnNonEnumNamesExpectedType() {
+        MethodArgumentTypeMismatchException ex = new MethodArgumentTypeMismatchException("abc", int.class, "page", null, null);
+
+        String body = String.valueOf(handler.handleTypeMismatch(ex).getBody());
+
+        assertEquals(400, handler.handleTypeMismatch(ex).getStatusCode().value());
+        assertTrue(body.contains("page"));
+    }
+}

--- a/pic-sure-auth-services/src/test/java/edu/harvard/hms/dbmi/avillach/auth/rest/ApiKeyControllerTest.java
+++ b/pic-sure-auth-services/src/test/java/edu/harvard/hms/dbmi/avillach/auth/rest/ApiKeyControllerTest.java
@@ -56,65 +56,65 @@ public class ApiKeyControllerTest {
     @Test
     public void testCreateUserKey_success() {
         when(captchaVerifier.verify(any(), any())).thenReturn(true);
-        when(apiKeyService.generateUserKey(anyString())).thenReturn(creationResponse);
+        when(apiKeyService.generateUserKey(any(), anyString())).thenReturn(creationResponse);
 
-        ResponseEntity<?> response = controller.createUserKey(new UserApiKeyRequest("captcha-token", "user@example.com"), request);
+        ResponseEntity<?> response = controller.createUserKey(new UserApiKeyRequest("captcha-token", "Jane Doe", "user@example.com"), request);
 
         assertEquals(200, response.getStatusCode().value());
         assertEquals(creationResponse, response.getBody());
-        verify(apiKeyService).generateUserKey("user@example.com");
+        verify(apiKeyService).generateUserKey("Jane Doe", "user@example.com");
     }
 
     @Test
     public void testCreateUserKey_blankEmailNormalizedToNull() {
         when(captchaVerifier.verify(any(), any())).thenReturn(true);
-        when(apiKeyService.generateUserKey(any())).thenReturn(creationResponse);
+        when(apiKeyService.generateUserKey(any(), any())).thenReturn(creationResponse);
 
-        controller.createUserKey(new UserApiKeyRequest("captcha-token", "  "), request);
+        controller.createUserKey(new UserApiKeyRequest("captcha-token", "  ", "  "), request);
 
-        verify(apiKeyService).generateUserKey(null);
+        verify(apiKeyService).generateUserKey(null, null);
     }
 
     @Test
     public void testCreateUserKey_captchaFailure() {
         when(captchaVerifier.verify(any(), any())).thenReturn(false);
 
-        ResponseEntity<?> response = controller.createUserKey(new UserApiKeyRequest("bad-token", null), request);
+        ResponseEntity<?> response = controller.createUserKey(new UserApiKeyRequest("bad-token", null, null), request);
 
         assertNotEquals(200, response.getStatusCode().value());
-        verify(apiKeyService, never()).generateUserKey(any());
+        verify(apiKeyService, never()).generateUserKey(any(), any());
     }
 
     @Test
     public void testCreateUserKey_openAccessDisabled() {
         controller = new ApiKeyController(apiKeyService, captchaVerifier, false, true);
 
-        ResponseEntity<?> response = controller.createUserKey(new UserApiKeyRequest("captcha-token", null), request);
+        ResponseEntity<?> response = controller.createUserKey(new UserApiKeyRequest("captcha-token", null, null), request);
 
         assertNotEquals(200, response.getStatusCode().value());
         verify(captchaVerifier, never()).verify(any(), any());
-        verify(apiKeyService, never()).generateUserKey(any());
+        verify(apiKeyService, never()).generateUserKey(any(), any());
     }
 
     @Test
     public void testCreateUserKey_generationDisabled() {
         controller = new ApiKeyController(apiKeyService, captchaVerifier, true, false);
 
-        ResponseEntity<?> response = controller.createUserKey(new UserApiKeyRequest("captcha-token", null), request);
+        ResponseEntity<?> response = controller.createUserKey(new UserApiKeyRequest("captcha-token", null, null), request);
 
         assertNotEquals(200, response.getStatusCode().value());
         verify(captchaVerifier, never()).verify(any(), any());
-        verify(apiKeyService, never()).generateUserKey(any());
+        verify(apiKeyService, never()).generateUserKey(any(), any());
     }
 
     @Test
     public void testCreateUserKey_oversizedEmailRejected() {
         when(captchaVerifier.verify(any(), any())).thenReturn(true);
 
-        ResponseEntity<?> response = controller.createUserKey(new UserApiKeyRequest("captcha-token", "a".repeat(250) + "@example.com"), request);
+        ResponseEntity<?> response = controller.createUserKey(new UserApiKeyRequest("captcha-token", null, "a".repeat(250) + "@example.com"), request);
 
         assertNotEquals(200, response.getStatusCode().value());
-        verify(apiKeyService, never()).generateUserKey(any());
+        verify(apiKeyService, never()).generateUserKey(any(), any());
     }
 
     @Test

--- a/pic-sure-auth-services/src/test/java/edu/harvard/hms/dbmi/avillach/auth/rest/ApiKeyControllerTest.java
+++ b/pic-sure-auth-services/src/test/java/edu/harvard/hms/dbmi/avillach/auth/rest/ApiKeyControllerTest.java
@@ -1,0 +1,206 @@
+package edu.harvard.hms.dbmi.avillach.auth.rest;
+
+import edu.harvard.hms.dbmi.avillach.auth.enums.ApiKeyType;
+import edu.harvard.hms.dbmi.avillach.auth.model.request.PlatformApiKeyRequest;
+import edu.harvard.hms.dbmi.avillach.auth.model.request.UserApiKeyRequest;
+import edu.harvard.hms.dbmi.avillach.auth.model.response.ApiKeyCreationResponse;
+import edu.harvard.hms.dbmi.avillach.auth.model.response.ApiKeyMetadata;
+import edu.harvard.hms.dbmi.avillach.auth.model.response.ApiKeyPage;
+import edu.harvard.hms.dbmi.avillach.auth.service.CaptchaVerifier;
+import edu.harvard.hms.dbmi.avillach.auth.service.impl.ApiKeyService;
+import jakarta.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockitoAnnotations;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.ResponseEntity;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.test.context.ContextConfiguration;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+@SpringBootTest
+@ContextConfiguration(classes = {ApiKeyController.class})
+public class ApiKeyControllerTest {
+
+    @MockBean
+    private ApiKeyService apiKeyService;
+
+    @MockBean
+    private CaptchaVerifier captchaVerifier;
+
+    private ApiKeyController controller;
+    private HttpServletRequest request;
+
+    private final ApiKeyCreationResponse creationResponse = new ApiKeyCreationResponse(
+        "picsure_0000000000000000000000000000000000000000000", UUID.randomUUID(), "00000000", ApiKeyType.USER,
+        Instant.now().plusSeconds(3600)
+    );
+
+    @BeforeEach
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+        controller = new ApiKeyController(apiKeyService, captchaVerifier, true, true);
+        request = new MockHttpServletRequest();
+    }
+
+    @Test
+    public void testCreateUserKey_success() {
+        when(captchaVerifier.verify(any(), any())).thenReturn(true);
+        when(apiKeyService.generateUserKey(anyString())).thenReturn(creationResponse);
+
+        ResponseEntity<?> response = controller.createUserKey(new UserApiKeyRequest("captcha-token", "user@example.com"), request);
+
+        assertEquals(200, response.getStatusCode().value());
+        assertEquals(creationResponse, response.getBody());
+        verify(apiKeyService).generateUserKey("user@example.com");
+    }
+
+    @Test
+    public void testCreateUserKey_blankEmailNormalizedToNull() {
+        when(captchaVerifier.verify(any(), any())).thenReturn(true);
+        when(apiKeyService.generateUserKey(any())).thenReturn(creationResponse);
+
+        controller.createUserKey(new UserApiKeyRequest("captcha-token", "  "), request);
+
+        verify(apiKeyService).generateUserKey(null);
+    }
+
+    @Test
+    public void testCreateUserKey_captchaFailure() {
+        when(captchaVerifier.verify(any(), any())).thenReturn(false);
+
+        ResponseEntity<?> response = controller.createUserKey(new UserApiKeyRequest("bad-token", null), request);
+
+        assertNotEquals(200, response.getStatusCode().value());
+        verify(apiKeyService, never()).generateUserKey(any());
+    }
+
+    @Test
+    public void testCreateUserKey_openAccessDisabled() {
+        controller = new ApiKeyController(apiKeyService, captchaVerifier, false, true);
+
+        ResponseEntity<?> response = controller.createUserKey(new UserApiKeyRequest("captcha-token", null), request);
+
+        assertNotEquals(200, response.getStatusCode().value());
+        verify(captchaVerifier, never()).verify(any(), any());
+        verify(apiKeyService, never()).generateUserKey(any());
+    }
+
+    @Test
+    public void testCreateUserKey_generationDisabled() {
+        controller = new ApiKeyController(apiKeyService, captchaVerifier, true, false);
+
+        ResponseEntity<?> response = controller.createUserKey(new UserApiKeyRequest("captcha-token", null), request);
+
+        assertNotEquals(200, response.getStatusCode().value());
+        verify(captchaVerifier, never()).verify(any(), any());
+        verify(apiKeyService, never()).generateUserKey(any());
+    }
+
+    @Test
+    public void testCreateUserKey_oversizedEmailRejected() {
+        when(captchaVerifier.verify(any(), any())).thenReturn(true);
+
+        ResponseEntity<?> response = controller.createUserKey(new UserApiKeyRequest("captcha-token", "a".repeat(250) + "@example.com"), request);
+
+        assertNotEquals(200, response.getStatusCode().value());
+        verify(apiKeyService, never()).generateUserKey(any());
+    }
+
+    @Test
+    public void testListKeys() {
+        ApiKeyMetadata metadata = new ApiKeyMetadata(
+            UUID.randomUUID(), "00000000", ApiKeyType.USER, null, null, Instant.now(), Instant.now().plusSeconds(3600), null, null
+        );
+        ApiKeyPage keyPage = new ApiKeyPage(List.of(metadata), 1, 0, 100);
+        when(apiKeyService.listKeys(0, 100)).thenReturn(keyPage);
+
+        ResponseEntity<ApiKeyPage> response = controller.listKeys(0, 100);
+
+        assertEquals(200, response.getStatusCode().value());
+        assertEquals(keyPage, response.getBody());
+    }
+
+    @Test
+    public void testListKeys_clampsPageParams() {
+        when(apiKeyService.listKeys(0, 1000)).thenReturn(new ApiKeyPage(List.of(), 0, 0, 1000));
+
+        controller.listKeys(-5, 999999);
+
+        verify(apiKeyService).listKeys(0, 1000);
+    }
+
+    @Test
+    public void testCreatePlatformKey_requiresNameAndEmail() {
+        assertNotEquals(200, controller.createPlatformKey(new PlatformApiKeyRequest(null, "a@b.com", null), request).getStatusCode().value());
+        assertNotEquals(200, controller.createPlatformKey(new PlatformApiKeyRequest("Partner", " ", null), request).getStatusCode().value());
+        verify(apiKeyService, never()).generatePlatformKey(any(), any(), any());
+    }
+
+    @Test
+    public void testCreatePlatformKey_oversizedNameRejected() {
+        ResponseEntity<?> response = controller.createPlatformKey(new PlatformApiKeyRequest("x".repeat(256), "a@b.com", null), request);
+
+        assertNotEquals(200, response.getStatusCode().value());
+        verify(apiKeyService, never()).generatePlatformKey(any(), any(), any());
+    }
+
+    @Test
+    public void testCreatePlatformKey_success() {
+        Instant expiresAt = Instant.now().plusSeconds(86400);
+        when(apiKeyService.generatePlatformKey("Partner", "a@b.com", expiresAt)).thenReturn(creationResponse);
+
+        ResponseEntity<?> response = controller.createPlatformKey(new PlatformApiKeyRequest("Partner", "a@b.com", expiresAt), request);
+
+        assertEquals(200, response.getStatusCode().value());
+        assertEquals(creationResponse, response.getBody());
+    }
+
+    @Test
+    public void testCreatePlatformKey_pastExpiryReturnsError() {
+        when(apiKeyService.generatePlatformKey(any(), any(), any())).thenThrow(new IllegalArgumentException("API key expiration must be in the future"));
+
+        ResponseEntity<?> response = controller.createPlatformKey(new PlatformApiKeyRequest("Partner", "a@b.com", Instant.now().minusSeconds(1)), request);
+
+        assertNotEquals(200, response.getStatusCode().value());
+    }
+
+    @Test
+    public void testRevokeKey_success() {
+        UUID uuid = UUID.randomUUID();
+        ApiKeyMetadata metadata = new ApiKeyMetadata(
+            uuid, "00000000", ApiKeyType.USER, null, null, Instant.now(), Instant.now().plusSeconds(3600), Instant.now(), null
+        );
+        when(apiKeyService.revokeKey(uuid)).thenReturn(Optional.of(metadata));
+
+        ResponseEntity<?> response = controller.revokeKey(uuid.toString(), request);
+
+        assertEquals(200, response.getStatusCode().value());
+        assertEquals(metadata, response.getBody());
+    }
+
+    @Test
+    public void testRevokeKey_notFound() {
+        when(apiKeyService.revokeKey(any(UUID.class))).thenReturn(Optional.empty());
+
+        assertNotEquals(200, controller.revokeKey(UUID.randomUUID().toString(), request).getStatusCode().value());
+    }
+
+    @Test
+    public void testRevokeKey_malformedUuid() {
+        ResponseEntity<?> response = controller.revokeKey("not-a-uuid", request);
+
+        assertNotEquals(200, response.getStatusCode().value());
+        verify(apiKeyService, never()).revokeKey(any(UUID.class));
+    }
+}

--- a/pic-sure-auth-services/src/test/java/edu/harvard/hms/dbmi/avillach/auth/rest/ApiKeyControllerTest.java
+++ b/pic-sure-auth-services/src/test/java/edu/harvard/hms/dbmi/avillach/auth/rest/ApiKeyControllerTest.java
@@ -11,12 +11,11 @@ import edu.harvard.hms.dbmi.avillach.auth.service.impl.ApiKeyService;
 import jakarta.servlet.http.HttpServletRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.MockitoAnnotations;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.ResponseEntity;
 import org.springframework.mock.web.MockHttpServletRequest;
-import org.springframework.test.context.ContextConfiguration;
 
 import java.time.Instant;
 import java.util.List;
@@ -28,14 +27,13 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
 
-@SpringBootTest
-@ContextConfiguration(classes = {ApiKeyController.class})
+@ExtendWith(MockitoExtension.class)
 public class ApiKeyControllerTest {
 
-    @MockBean
+    @Mock
     private ApiKeyService apiKeyService;
 
-    @MockBean
+    @Mock
     private CaptchaVerifier captchaVerifier;
 
     private ApiKeyController controller;
@@ -48,7 +46,6 @@ public class ApiKeyControllerTest {
 
     @BeforeEach
     public void setUp() {
-        MockitoAnnotations.openMocks(this);
         controller = new ApiKeyController(apiKeyService, captchaVerifier, true, true);
         request = new MockHttpServletRequest();
     }
@@ -119,8 +116,7 @@ public class ApiKeyControllerTest {
 
     @Test
     public void testCreateUserKey_oversizedEmailRejected() {
-        when(captchaVerifier.verify(any(), any())).thenReturn(true);
-
+        // no stubs: the length check must reject before the CAPTCHA or service is ever consulted
         ResponseEntity<?> response = controller.createUserKey(new UserApiKeyRequest("captcha-token", null, "a".repeat(250) + "@example.com"), request);
 
         assertNotEquals(200, response.getStatusCode().value());

--- a/pic-sure-auth-services/src/test/java/edu/harvard/hms/dbmi/avillach/auth/rest/ApiKeyControllerTest.java
+++ b/pic-sure-auth-services/src/test/java/edu/harvard/hms/dbmi/avillach/auth/rest/ApiKeyControllerTest.java
@@ -123,21 +123,39 @@ public class ApiKeyControllerTest {
             UUID.randomUUID(), "00000000", ApiKeyType.USER, null, null, Instant.now(), Instant.now().plusSeconds(3600), null, null
         );
         ApiKeyPage keyPage = new ApiKeyPage(List.of(metadata), 1, 0, 100);
-        when(apiKeyService.listKeys(0, 100)).thenReturn(keyPage);
+        when(apiKeyService.listKeys(0, 100, null)).thenReturn(keyPage);
 
-        ResponseEntity<ApiKeyPage> response = controller.listKeys(0, 100);
+        ResponseEntity<?> response = controller.listKeys(0, 100, null);
 
         assertEquals(200, response.getStatusCode().value());
         assertEquals(keyPage, response.getBody());
     }
 
     @Test
+    public void testListKeys_filtersByKeyType() {
+        ApiKeyPage keyPage = new ApiKeyPage(List.of(), 0, 0, 100);
+        when(apiKeyService.listKeys(0, 100, ApiKeyType.PLATFORM)).thenReturn(keyPage);
+
+        controller.listKeys(0, 100, "platform");
+
+        verify(apiKeyService).listKeys(0, 100, ApiKeyType.PLATFORM);
+    }
+
+    @Test
+    public void testListKeys_invalidKeyTypeReturns400NotError() {
+        ResponseEntity<?> response = controller.listKeys(0, 100, "not-a-type");
+
+        assertNotEquals(200, response.getStatusCode().value());
+        verify(apiKeyService, never()).listKeys(anyInt(), anyInt(), any());
+    }
+
+    @Test
     public void testListKeys_clampsPageParams() {
-        when(apiKeyService.listKeys(0, 1000)).thenReturn(new ApiKeyPage(List.of(), 0, 0, 1000));
+        when(apiKeyService.listKeys(0, 1000, null)).thenReturn(new ApiKeyPage(List.of(), 0, 0, 1000));
 
-        controller.listKeys(-5, 999999);
+        controller.listKeys(-5, 999999, null);
 
-        verify(apiKeyService).listKeys(0, 1000);
+        verify(apiKeyService).listKeys(0, 1000, null);
     }
 
     @Test

--- a/pic-sure-auth-services/src/test/java/edu/harvard/hms/dbmi/avillach/auth/rest/ApiKeyControllerTest.java
+++ b/pic-sure-auth-services/src/test/java/edu/harvard/hms/dbmi/avillach/auth/rest/ApiKeyControllerTest.java
@@ -76,6 +76,16 @@ public class ApiKeyControllerTest {
     }
 
     @Test
+    public void testCreateUserKey_controlCharactersStripped() {
+        when(captchaVerifier.verify(any(), any())).thenReturn(true);
+        when(apiKeyService.generateUserKey(any(), any())).thenReturn(creationResponse);
+
+        controller.createUserKey(new UserApiKeyRequest("captcha-token", "Jane\nDoe", "user@example.com\r\n"), request);
+
+        verify(apiKeyService).generateUserKey("JaneDoe", "user@example.com");
+    }
+
+    @Test
     public void testCreateUserKey_captchaFailure() {
         when(captchaVerifier.verify(any(), any())).thenReturn(false);
 
@@ -221,6 +231,7 @@ public class ApiKeyControllerTest {
         ResponseEntity<?> response = controller.revokeKey("not-a-uuid", request);
 
         assertNotEquals(200, response.getStatusCode().value());
+        assertFalse(String.valueOf(response.getBody()).contains("not-a-uuid"));
         verify(apiKeyService, never()).revokeKey(any(UUID.class));
     }
 }

--- a/pic-sure-auth-services/src/test/java/edu/harvard/hms/dbmi/avillach/auth/rest/ApiKeyControllerTest.java
+++ b/pic-sure-auth-services/src/test/java/edu/harvard/hms/dbmi/avillach/auth/rest/ApiKeyControllerTest.java
@@ -136,17 +136,19 @@ public class ApiKeyControllerTest {
         ApiKeyPage keyPage = new ApiKeyPage(List.of(), 0, 0, 100);
         when(apiKeyService.listKeys(0, 100, ApiKeyType.PLATFORM)).thenReturn(keyPage);
 
-        controller.listKeys(0, 100, "platform");
+        controller.listKeys(0, 100, ApiKeyType.PLATFORM);
 
         verify(apiKeyService).listKeys(0, 100, ApiKeyType.PLATFORM);
     }
 
     @Test
-    public void testListKeys_invalidKeyTypeReturns400NotError() {
-        ResponseEntity<?> response = controller.listKeys(0, 100, "not-a-type");
+    public void testCreatePlatformKey_neverExpiresPassedThrough() {
+        when(apiKeyService.generatePlatformKey("Partner", "a@b.com", null, true)).thenReturn(creationResponse);
 
-        assertNotEquals(200, response.getStatusCode().value());
-        verify(apiKeyService, never()).listKeys(anyInt(), anyInt(), any());
+        ResponseEntity<?> response = controller.createPlatformKey(new PlatformApiKeyRequest("Partner", "a@b.com", null, true), request);
+
+        assertEquals(200, response.getStatusCode().value());
+        verify(apiKeyService).generatePlatformKey("Partner", "a@b.com", null, true);
     }
 
     @Test
@@ -160,25 +162,25 @@ public class ApiKeyControllerTest {
 
     @Test
     public void testCreatePlatformKey_requiresNameAndEmail() {
-        assertNotEquals(200, controller.createPlatformKey(new PlatformApiKeyRequest(null, "a@b.com", null), request).getStatusCode().value());
-        assertNotEquals(200, controller.createPlatformKey(new PlatformApiKeyRequest("Partner", " ", null), request).getStatusCode().value());
-        verify(apiKeyService, never()).generatePlatformKey(any(), any(), any());
+        assertNotEquals(200, controller.createPlatformKey(new PlatformApiKeyRequest(null, "a@b.com", null, false), request).getStatusCode().value());
+        assertNotEquals(200, controller.createPlatformKey(new PlatformApiKeyRequest("Partner", " ", null, false), request).getStatusCode().value());
+        verify(apiKeyService, never()).generatePlatformKey(any(), any(), any(), anyBoolean());
     }
 
     @Test
     public void testCreatePlatformKey_oversizedNameRejected() {
-        ResponseEntity<?> response = controller.createPlatformKey(new PlatformApiKeyRequest("x".repeat(256), "a@b.com", null), request);
+        ResponseEntity<?> response = controller.createPlatformKey(new PlatformApiKeyRequest("x".repeat(256), "a@b.com", null, false), request);
 
         assertNotEquals(200, response.getStatusCode().value());
-        verify(apiKeyService, never()).generatePlatformKey(any(), any(), any());
+        verify(apiKeyService, never()).generatePlatformKey(any(), any(), any(), anyBoolean());
     }
 
     @Test
     public void testCreatePlatformKey_success() {
         Instant expiresAt = Instant.now().plusSeconds(86400);
-        when(apiKeyService.generatePlatformKey("Partner", "a@b.com", expiresAt)).thenReturn(creationResponse);
+        when(apiKeyService.generatePlatformKey("Partner", "a@b.com", expiresAt, false)).thenReturn(creationResponse);
 
-        ResponseEntity<?> response = controller.createPlatformKey(new PlatformApiKeyRequest("Partner", "a@b.com", expiresAt), request);
+        ResponseEntity<?> response = controller.createPlatformKey(new PlatformApiKeyRequest("Partner", "a@b.com", expiresAt, false), request);
 
         assertEquals(200, response.getStatusCode().value());
         assertEquals(creationResponse, response.getBody());
@@ -186,9 +188,9 @@ public class ApiKeyControllerTest {
 
     @Test
     public void testCreatePlatformKey_pastExpiryReturnsError() {
-        when(apiKeyService.generatePlatformKey(any(), any(), any())).thenThrow(new IllegalArgumentException("API key expiration must be in the future"));
+        when(apiKeyService.generatePlatformKey(any(), any(), any(), anyBoolean())).thenThrow(new IllegalArgumentException("API key expiration must be in the future"));
 
-        ResponseEntity<?> response = controller.createPlatformKey(new PlatformApiKeyRequest("Partner", "a@b.com", Instant.now().minusSeconds(1)), request);
+        ResponseEntity<?> response = controller.createPlatformKey(new PlatformApiKeyRequest("Partner", "a@b.com", Instant.now().minusSeconds(1), false), request);
 
         assertNotEquals(200, response.getStatusCode().value());
     }

--- a/pic-sure-auth-services/src/test/java/edu/harvard/hms/dbmi/avillach/auth/rest/ApiKeyControllerWebTest.java
+++ b/pic-sure-auth-services/src/test/java/edu/harvard/hms/dbmi/avillach/auth/rest/ApiKeyControllerWebTest.java
@@ -1,0 +1,77 @@
+package edu.harvard.hms.dbmi.avillach.auth.rest;
+
+import edu.harvard.hms.dbmi.avillach.auth.enums.ApiKeyType;
+import edu.harvard.hms.dbmi.avillach.auth.exceptions.GlobalExceptionHandler;
+import edu.harvard.hms.dbmi.avillach.auth.model.response.ApiKeyPage;
+import edu.harvard.hms.dbmi.avillach.auth.service.impl.ApiKeyService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Standalone MockMvc tests: exercise real JSON deserialization and request-parameter conversion
+ * through the {@link GlobalExceptionHandler} advice, which plain controller unit tests bypass.
+ */
+public class ApiKeyControllerWebTest {
+
+    private MockMvc mockMvc;
+    private ApiKeyService apiKeyService;
+
+    @BeforeEach
+    public void setUp() {
+        apiKeyService = Mockito.mock(ApiKeyService.class);
+        ApiKeyController controller = new ApiKeyController(apiKeyService, (token, ip) -> true, true, true);
+        mockMvc = MockMvcBuilders.standaloneSetup(controller).setControllerAdvice(new GlobalExceptionHandler()).build();
+    }
+
+    @Test
+    public void testMalformedJsonBodyReturns400WithoutParserDetails() throws Exception {
+        MvcResult result = mockMvc
+            .perform(post("/apiKey/platform").contentType(MediaType.APPLICATION_JSON).content("{ this is not json"))
+            .andExpect(status().isBadRequest()).andReturn();
+
+        assertFalse(result.getResponse().getContentAsString().contains("fasterxml"));
+    }
+
+    @Test
+    public void testMissingBodyReturns400() throws Exception {
+        mockMvc.perform(post("/apiKey/platform").contentType(MediaType.APPLICATION_JSON)).andExpect(status().isBadRequest());
+    }
+
+    @Test
+    public void testUnparseableExpiresAtReturns400() throws Exception {
+        mockMvc.perform(
+            post("/apiKey/platform").contentType(MediaType.APPLICATION_JSON)
+                .content("{\"name\":\"Partner\",\"email\":\"a@b.com\",\"expiresAt\":\"not-a-date\"}")
+        ).andExpect(status().isBadRequest());
+    }
+
+    @Test
+    public void testInvalidKeyTypeParamReturns400WithoutEchoingValue() throws Exception {
+        MvcResult result =
+            mockMvc.perform(get("/apiKey").param("keyType", "bogus-type")).andExpect(status().isBadRequest()).andReturn();
+
+        assertFalse(result.getResponse().getContentAsString().contains("bogus-type"));
+    }
+
+    @Test
+    public void testValidKeyTypeParamBindsCaseInsensitively() throws Exception {
+        when(apiKeyService.listKeys(anyInt(), anyInt(), eq(ApiKeyType.PLATFORM))).thenReturn(new ApiKeyPage(List.of(), 0, 0, 100));
+
+        mockMvc.perform(get("/apiKey").param("keyType", "PLATFORM")).andExpect(status().isOk());
+    }
+}

--- a/pic-sure-auth-services/src/test/java/edu/harvard/hms/dbmi/avillach/auth/rest/ControllerAuditEventTest.java
+++ b/pic-sure-auth-services/src/test/java/edu/harvard/hms/dbmi/avillach/auth/rest/ControllerAuditEventTest.java
@@ -151,8 +151,8 @@ class ControllerAuditEventTest {
             new Class[]{edu.harvard.hms.dbmi.avillach.auth.model.request.UserApiKeyRequest.class, HttpServletRequest.class}, "ACCESS",
             "api_key.create"
         );
-        // listKeys(int page, int size)
-        assertAuditEvent(c, "listKeys", new Class[]{int.class, int.class}, "OTHER", "api_key.list");
+        // listKeys(int page, int size, String keyType)
+        assertAuditEvent(c, "listKeys", new Class[]{int.class, int.class, String.class}, "OTHER", "api_key.list");
         // createPlatformKey(PlatformApiKeyRequest keyRequest, HttpServletRequest request)
         assertAuditEvent(
             c, "createPlatformKey",

--- a/pic-sure-auth-services/src/test/java/edu/harvard/hms/dbmi/avillach/auth/rest/ControllerAuditEventTest.java
+++ b/pic-sure-auth-services/src/test/java/edu/harvard/hms/dbmi/avillach/auth/rest/ControllerAuditEventTest.java
@@ -143,6 +143,27 @@ class ControllerAuditEventTest {
     }
 
     @Test
+    void apiKeyController() throws Exception {
+        Class<?> c = ApiKeyController.class;
+        // createUserKey(UserApiKeyRequest keyRequest, HttpServletRequest request)
+        assertAuditEvent(
+            c, "createUserKey",
+            new Class[]{edu.harvard.hms.dbmi.avillach.auth.model.request.UserApiKeyRequest.class, HttpServletRequest.class}, "ACCESS",
+            "api_key.create"
+        );
+        // listKeys(int page, int size)
+        assertAuditEvent(c, "listKeys", new Class[]{int.class, int.class}, "OTHER", "api_key.list");
+        // createPlatformKey(PlatformApiKeyRequest keyRequest, HttpServletRequest request)
+        assertAuditEvent(
+            c, "createPlatformKey",
+            new Class[]{edu.harvard.hms.dbmi.avillach.auth.model.request.PlatformApiKeyRequest.class, HttpServletRequest.class}, "ADMIN",
+            "api_key.platform.create"
+        );
+        // revokeKey(String keyId, HttpServletRequest request)
+        assertAuditEvent(c, "revokeKey", new Class[]{String.class, HttpServletRequest.class}, "ADMIN", "api_key.revoke");
+    }
+
+    @Test
     void studyAccessController() throws Exception {
         Class<?> c = StudyAccessController.class;
         // addStudyAccess(String studyIdentifier, HttpServletRequest request)

--- a/pic-sure-auth-services/src/test/java/edu/harvard/hms/dbmi/avillach/auth/rest/ControllerAuditEventTest.java
+++ b/pic-sure-auth-services/src/test/java/edu/harvard/hms/dbmi/avillach/auth/rest/ControllerAuditEventTest.java
@@ -151,8 +151,11 @@ class ControllerAuditEventTest {
             new Class[]{edu.harvard.hms.dbmi.avillach.auth.model.request.UserApiKeyRequest.class, HttpServletRequest.class}, "ACCESS",
             "api_key.create"
         );
-        // listKeys(int page, int size, String keyType)
-        assertAuditEvent(c, "listKeys", new Class[]{int.class, int.class, String.class}, "OTHER", "api_key.list");
+        // listKeys(int page, int size, ApiKeyType keyType)
+        assertAuditEvent(
+            c, "listKeys", new Class[]{int.class, int.class, edu.harvard.hms.dbmi.avillach.auth.enums.ApiKeyType.class}, "OTHER",
+            "api_key.list"
+        );
         // createPlatformKey(PlatformApiKeyRequest keyRequest, HttpServletRequest request)
         assertAuditEvent(
             c, "createPlatformKey",

--- a/pic-sure-auth-services/src/test/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/ApiKeyServiceTest.java
+++ b/pic-sure-auth-services/src/test/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/ApiKeyServiceTest.java
@@ -296,6 +296,16 @@ public class ApiKeyServiceTest {
     }
 
     @Test
+    public void testVerifyKey_nullExpiryUserKeyRejected() {
+        ApiKeyCreationResponse response = apiKeyService.generateUserKey(null, null);
+        // such a row can only exist where a deployment schema is missing the platform-only CHECK
+        ApiKey stored = storedKeyFor(response).setExpiresAt(null);
+        when(apiKeyRepository.findByKeyHash(stored.getKeyHash())).thenReturn(Optional.of(stored));
+
+        assertTrue(apiKeyService.verifyKey(response.apiKey()).isEmpty());
+    }
+
+    @Test
     public void testConstructor_rejectsNonPositiveTtl() {
         assertThrows(IllegalStateException.class, () -> new ApiKeyService(apiKeyRepository, "", "", USER_TTL_DAYS, 0));
         assertThrows(IllegalStateException.class, () -> new ApiKeyService(apiKeyRepository, "", "", 0, PLATFORM_TTL_DAYS));

--- a/pic-sure-auth-services/src/test/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/ApiKeyServiceTest.java
+++ b/pic-sure-auth-services/src/test/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/ApiKeyServiceTest.java
@@ -1,0 +1,341 @@
+package edu.harvard.hms.dbmi.avillach.auth.service.impl;
+
+import edu.harvard.hms.dbmi.avillach.auth.entity.ApiKey;
+import edu.harvard.hms.dbmi.avillach.auth.enums.ApiKeyType;
+import edu.harvard.hms.dbmi.avillach.auth.model.response.ApiKeyCreationResponse;
+import edu.harvard.hms.dbmi.avillach.auth.model.response.ApiKeyMetadata;
+import edu.harvard.hms.dbmi.avillach.auth.repository.ApiKeyRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.MockitoAnnotations;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ContextConfiguration;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.HexFormat;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@SpringBootTest
+@ContextConfiguration(classes = {ApiKeyService.class})
+public class ApiKeyServiceTest {
+
+    private static final long USER_TTL_DAYS = 90;
+
+    @MockBean
+    private ApiKeyRepository apiKeyRepository;
+
+    private ApiKeyService apiKeyService;
+
+    @BeforeEach
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+        when(apiKeyRepository.save(any(ApiKey.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        apiKeyService = new ApiKeyService(apiKeyRepository, "", "", USER_TTL_DAYS);
+    }
+
+    @Test
+    public void testGenerateUserKey_formatAndPersistedFields() {
+        ApiKeyCreationResponse response = apiKeyService.generateUserKey("user@example.com");
+
+        assertTrue(response.apiKey().matches("^picsure_[0-9A-Za-z]{43}$"));
+        assertEquals(response.apiKey().substring("picsure_".length(), "picsure_".length() + 8), response.displayPrefix());
+        assertEquals(ApiKeyType.USER, response.keyType());
+
+        ArgumentCaptor<ApiKey> captor = ArgumentCaptor.forClass(ApiKey.class);
+        verify(apiKeyRepository).save(captor.capture());
+        ApiKey saved = captor.getValue();
+        assertEquals(sha256(response.apiKey()), saved.getKeyHash());
+        assertEquals(ApiKeyService.SCHEME_SHA256, saved.getHashScheme());
+        assertEquals(ApiKeyType.USER, saved.getKeyType());
+        assertEquals("user@example.com", saved.getEmail());
+        assertNull(saved.getName());
+        assertNull(saved.getRevokedAt());
+        assertNull(saved.getLastUsedAt());
+        long ttlDays = ChronoUnit.DAYS.between(saved.getCreatedAt(), saved.getExpiresAt());
+        assertEquals(USER_TTL_DAYS, ttlDays);
+        assertFalse(saved.getKeyHash().contains(response.apiKey()));
+    }
+
+    @Test
+    public void testGenerateUserKey_withPepperUsesHmacScheme() {
+        apiKeyService = new ApiKeyService(apiKeyRepository, "test-pepper", "", USER_TTL_DAYS);
+
+        ApiKeyCreationResponse response = apiKeyService.generateUserKey(null);
+
+        ArgumentCaptor<ApiKey> captor = ArgumentCaptor.forClass(ApiKey.class);
+        verify(apiKeyRepository).save(captor.capture());
+        ApiKey saved = captor.getValue();
+        assertEquals(ApiKeyService.SCHEME_HMAC_SHA256, saved.getHashScheme());
+        assertNotEquals(sha256(response.apiKey()), saved.getKeyHash());
+    }
+
+    @Test
+    public void testGeneratePlatformKey_customExpiryAndMetadata() {
+        Instant expiresAt = Instant.now().plus(365, ChronoUnit.DAYS);
+
+        ApiKeyCreationResponse response = apiKeyService.generatePlatformKey("Partner X", "partner@example.com", expiresAt);
+
+        assertEquals(ApiKeyType.PLATFORM, response.keyType());
+        assertEquals(expiresAt, response.expiresAt());
+        ArgumentCaptor<ApiKey> captor = ArgumentCaptor.forClass(ApiKey.class);
+        verify(apiKeyRepository).save(captor.capture());
+        assertEquals("Partner X", captor.getValue().getName());
+        assertEquals("partner@example.com", captor.getValue().getEmail());
+    }
+
+    @Test
+    public void testVerifyKey_validKey() {
+        ApiKeyCreationResponse response = apiKeyService.generateUserKey(null);
+        ApiKey stored = storedKeyFor(response);
+        when(apiKeyRepository.findByKeyHash(stored.getKeyHash())).thenReturn(Optional.of(stored));
+
+        Optional<ApiKey> verified = apiKeyService.verifyKey(response.apiKey());
+
+        assertTrue(verified.isPresent());
+        assertEquals(ApiKeyType.USER, verified.get().getKeyType());
+    }
+
+    @Test
+    public void testVerifyKey_wrongPrefixSkipsLookup() {
+        assertTrue(apiKeyService.verifyKey("sk_live_notourkey").isEmpty());
+        assertTrue(apiKeyService.verifyKey(null).isEmpty());
+        verify(apiKeyRepository, never()).findByKeyHash(anyString());
+    }
+
+    @Test
+    public void testVerifyKey_unknownKey() {
+        when(apiKeyRepository.findByKeyHash(anyString())).thenReturn(Optional.empty());
+
+        assertTrue(apiKeyService.verifyKey("picsure_0000000000000000000000000000000000000000000").isEmpty());
+    }
+
+    @Test
+    public void testVerifyKey_revokedKey() {
+        ApiKeyCreationResponse response = apiKeyService.generateUserKey(null);
+        ApiKey stored = storedKeyFor(response).setRevokedAt(Instant.now());
+        when(apiKeyRepository.findByKeyHash(stored.getKeyHash())).thenReturn(Optional.of(stored));
+
+        assertTrue(apiKeyService.verifyKey(response.apiKey()).isEmpty());
+    }
+
+    @Test
+    public void testVerifyKey_expiredKey() {
+        ApiKeyCreationResponse response = apiKeyService.generateUserKey(null);
+        ApiKey stored = storedKeyFor(response).setExpiresAt(Instant.now().minusSeconds(1));
+        when(apiKeyRepository.findByKeyHash(stored.getKeyHash())).thenReturn(Optional.of(stored));
+
+        assertTrue(apiKeyService.verifyKey(response.apiKey()).isEmpty());
+    }
+
+    @Test
+    public void testVerifyKey_prePepperKeyStillVerifiesAfterPepperEnabled() {
+        // key minted while no pepper was configured...
+        ApiKeyCreationResponse response = apiKeyService.generateUserKey(null);
+        ApiKey stored = storedKeyFor(response);
+        when(apiKeyRepository.findByKeyHash(anyString())).thenReturn(Optional.empty());
+        when(apiKeyRepository.findByKeyHash(stored.getKeyHash())).thenReturn(Optional.of(stored));
+
+        // ...must still verify on a service configured with a pepper
+        ApiKeyService pepperedService = new ApiKeyService(apiKeyRepository, "test-pepper", "", USER_TTL_DAYS);
+        Optional<ApiKey> verified = pepperedService.verifyKey(response.apiKey());
+
+        assertTrue(verified.isPresent());
+        assertEquals(ApiKeyService.SCHEME_SHA256, verified.get().getHashScheme());
+    }
+
+    @Test
+    public void testVerifyKey_updatesLastUsedWhenStale() {
+        ApiKeyCreationResponse response = apiKeyService.generateUserKey(null);
+        ApiKey stored = storedKeyFor(response).setLastUsedAt(Instant.now().minusSeconds(300));
+        when(apiKeyRepository.findByKeyHash(stored.getKeyHash())).thenReturn(Optional.of(stored));
+        clearInvocations(apiKeyRepository);
+
+        apiKeyService.verifyKey(response.apiKey());
+
+        verify(apiKeyRepository).touchLastUsed(eq(stored.getUuid()), any(Instant.class));
+        verify(apiKeyRepository, never()).save(any(ApiKey.class));
+    }
+
+    @Test
+    public void testVerifyKey_skipsLastUsedWriteWhenRecent() {
+        ApiKeyCreationResponse response = apiKeyService.generateUserKey(null);
+        ApiKey stored = storedKeyFor(response).setLastUsedAt(Instant.now().minusSeconds(5));
+        when(apiKeyRepository.findByKeyHash(stored.getKeyHash())).thenReturn(Optional.of(stored));
+        clearInvocations(apiKeyRepository);
+
+        assertTrue(apiKeyService.verifyKey(response.apiKey()).isPresent());
+
+        verify(apiKeyRepository, never()).touchLastUsed(any(UUID.class), any(Instant.class));
+        verify(apiKeyRepository, never()).save(any(ApiKey.class));
+    }
+
+    @Test
+    public void testRevokeKey_setsRevokedAtOnce() {
+        UUID uuid = UUID.randomUUID();
+        ApiKey stored = new ApiKey().setDisplayPrefix("abcdefgh").setKeyType(ApiKeyType.USER).setCreatedAt(Instant.now())
+            .setExpiresAt(Instant.now().plusSeconds(3600));
+        stored.setUuid(uuid);
+        when(apiKeyRepository.findById(uuid)).thenReturn(Optional.of(stored));
+
+        Optional<ApiKeyMetadata> revoked = apiKeyService.revokeKey(uuid);
+
+        assertTrue(revoked.isPresent());
+        assertNotNull(revoked.get().revokedAt());
+        Instant firstRevokedAt = stored.getRevokedAt();
+        clearInvocations(apiKeyRepository);
+
+        apiKeyService.revokeKey(uuid);
+
+        assertEquals(firstRevokedAt, stored.getRevokedAt());
+        verify(apiKeyRepository, never()).save(any(ApiKey.class));
+    }
+
+    @Test
+    public void testVerifyKey_keyFromRotatedPepperStillVerifies() {
+        // key minted under the old pepper...
+        ApiKeyService oldPepperService = new ApiKeyService(apiKeyRepository, "old-pepper", "", USER_TTL_DAYS);
+        ApiKeyCreationResponse response = oldPepperService.generateUserKey(null);
+        ApiKey stored = storedKeyFor(response);
+        when(apiKeyRepository.findByKeyHash(anyString())).thenReturn(Optional.empty());
+        when(apiKeyRepository.findByKeyHash(stored.getKeyHash())).thenReturn(Optional.of(stored));
+
+        // ...verifies after rotation to a new pepper with the old one kept as previous
+        ApiKeyService rotatedService = new ApiKeyService(apiKeyRepository, "new-pepper", "old-pepper", USER_TTL_DAYS);
+        assertTrue(rotatedService.verifyKey(response.apiKey()).isPresent());
+
+        // ...and while the current pepper is accidentally omitted entirely
+        ApiKeyService pepperlessService = new ApiKeyService(apiKeyRepository, "", "old-pepper", USER_TTL_DAYS);
+        assertTrue(pepperlessService.verifyKey(response.apiKey()).isPresent());
+    }
+
+    @Test
+    public void testVerifyKey_keyFromTwoRotationsAgoVerifiesViaPepperList() {
+        ApiKeyService oldestPepperService = new ApiKeyService(apiKeyRepository, "pepper-v1", "", USER_TTL_DAYS);
+        ApiKeyCreationResponse response = oldestPepperService.generateUserKey(null);
+        ApiKey stored = storedKeyFor(response);
+        when(apiKeyRepository.findByKeyHash(anyString())).thenReturn(Optional.empty());
+        when(apiKeyRepository.findByKeyHash(stored.getKeyHash())).thenReturn(Optional.of(stored));
+
+        ApiKeyService twiceRotatedService = new ApiKeyService(apiKeyRepository, "pepper-v3", "pepper-v2, pepper-v1", USER_TTL_DAYS);
+
+        assertTrue(twiceRotatedService.verifyKey(response.apiKey()).isPresent());
+    }
+
+    @Test
+    public void testVerifyKey_lastUsedWriteFailureDoesNotRejectKey() {
+        ApiKeyCreationResponse response = apiKeyService.generateUserKey(null);
+        ApiKey stored = storedKeyFor(response);
+        when(apiKeyRepository.findByKeyHash(stored.getKeyHash())).thenReturn(Optional.of(stored));
+        when(apiKeyRepository.touchLastUsed(any(UUID.class), any(Instant.class))).thenThrow(new RuntimeException("db is read-only"));
+
+        assertTrue(apiKeyService.verifyKey(response.apiKey()).isPresent());
+    }
+
+    @Test
+    public void testGeneratePlatformKey_pastExpiryRejected() {
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> apiKeyService.generatePlatformKey("Partner X", "partner@example.com", Instant.now().minusSeconds(1))
+        );
+        verify(apiKeyRepository, never()).save(any(ApiKey.class));
+    }
+
+    @Test
+    public void testGeneratePlatformKey_nullExpiryFallsBackToUserTtl() {
+        ApiKeyCreationResponse response = apiKeyService.generatePlatformKey("Partner X", "partner@example.com", null);
+
+        ArgumentCaptor<ApiKey> captor = ArgumentCaptor.forClass(ApiKey.class);
+        verify(apiKeyRepository).save(captor.capture());
+        assertEquals(USER_TTL_DAYS, ChronoUnit.DAYS.between(captor.getValue().getCreatedAt(), captor.getValue().getExpiresAt()));
+        assertEquals(ApiKeyType.PLATFORM, response.keyType());
+    }
+
+    @Test
+    public void testConstructor_rejectsNonPositiveTtl() {
+        assertThrows(IllegalStateException.class, () -> new ApiKeyService(apiKeyRepository, "", "", 0));
+        assertThrows(IllegalStateException.class, () -> new ApiKeyService(apiKeyRepository, "", "", -1));
+    }
+
+    @Test
+    public void testVerifyKey_hmacKeyRejectedWhenNoPeppersConfigured() {
+        // key minted under a pepper, presented to a service with no peppers at all: the SHA256
+        // fallback lookup must not accept the HMAC-schemed row
+        ApiKeyService pepperedService = new ApiKeyService(apiKeyRepository, "test-pepper", "", USER_TTL_DAYS);
+        ApiKeyCreationResponse response = pepperedService.generateUserKey(null);
+        ApiKey stored = storedKeyFor(response);
+        when(apiKeyRepository.findByKeyHash(anyString())).thenReturn(Optional.empty());
+        when(apiKeyRepository.findByKeyHash(stored.getKeyHash())).thenReturn(Optional.of(stored));
+
+        assertTrue(apiKeyService.verifyKey(response.apiKey()).isEmpty());
+    }
+
+    @Test
+    public void testCreationResponse_toStringRedactsPlaintext() {
+        ApiKeyCreationResponse response = apiKeyService.generateUserKey(null);
+
+        assertFalse(response.toString().contains(response.apiKey()));
+        assertTrue(response.toString().contains(response.displayPrefix()));
+    }
+
+    @Test
+    public void testListKeys_mapsAllMetadataFields() {
+        Instant createdAt = Instant.now().minusSeconds(3600);
+        Instant expiresAt = Instant.now().plusSeconds(3600);
+        Instant revokedAt = Instant.now().minusSeconds(60);
+        Instant lastUsedAt = Instant.now().minusSeconds(120);
+        ApiKey stored = new ApiKey().setKeyHash("deadbeef").setHashScheme(ApiKeyService.SCHEME_SHA256).setDisplayPrefix("abcdefgh")
+            .setKeyType(ApiKeyType.PLATFORM).setName("Partner X").setEmail("partner@example.com").setCreatedAt(createdAt)
+            .setExpiresAt(expiresAt).setRevokedAt(revokedAt).setLastUsedAt(lastUsedAt);
+        stored.setUuid(UUID.randomUUID());
+        when(apiKeyRepository.findAllByOrderByCreatedAtDesc()).thenReturn(java.util.List.of(stored));
+
+        java.util.List<ApiKeyMetadata> keys = apiKeyService.listKeys();
+
+        assertEquals(1, keys.size());
+        ApiKeyMetadata metadata = keys.get(0);
+        assertEquals(stored.getUuid(), metadata.uuid());
+        assertEquals("abcdefgh", metadata.displayPrefix());
+        assertEquals(ApiKeyType.PLATFORM, metadata.keyType());
+        assertEquals("Partner X", metadata.name());
+        assertEquals("partner@example.com", metadata.email());
+        assertEquals(createdAt, metadata.createdAt());
+        assertEquals(expiresAt, metadata.expiresAt());
+        assertEquals(revokedAt, metadata.revokedAt());
+        assertEquals(lastUsedAt, metadata.lastUsedAt());
+    }
+
+    @Test
+    public void testRevokeKey_unknownUuid() {
+        when(apiKeyRepository.findById(any(UUID.class))).thenReturn(Optional.empty());
+
+        assertTrue(apiKeyService.revokeKey(UUID.randomUUID()).isEmpty());
+    }
+
+    private ApiKey storedKeyFor(ApiKeyCreationResponse response) {
+        ArgumentCaptor<ApiKey> captor = ArgumentCaptor.forClass(ApiKey.class);
+        verify(apiKeyRepository, atLeastOnce()).save(captor.capture());
+        ApiKey stored = captor.getValue();
+        stored.setUuid(UUID.randomUUID());
+        return stored;
+    }
+
+    private static String sha256(String value) {
+        try {
+            return HexFormat.of().formatHex(MessageDigest.getInstance("SHA-256").digest(value.getBytes(StandardCharsets.UTF_8)));
+        } catch (Exception e) {
+            throw new IllegalStateException(e);
+        }
+    }
+}

--- a/pic-sure-auth-services/src/test/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/ApiKeyServiceTest.java
+++ b/pic-sure-auth-services/src/test/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/ApiKeyServiceTest.java
@@ -299,12 +299,14 @@ public class ApiKeyServiceTest {
             .setKeyType(ApiKeyType.PLATFORM).setName("Partner X").setEmail("partner@example.com").setCreatedAt(createdAt)
             .setExpiresAt(expiresAt).setRevokedAt(revokedAt).setLastUsedAt(lastUsedAt);
         stored.setUuid(UUID.randomUUID());
-        when(apiKeyRepository.findAllByOrderByCreatedAtDesc()).thenReturn(java.util.List.of(stored));
+        when(apiKeyRepository.findAll(any(org.springframework.data.domain.Pageable.class)))
+            .thenReturn(new org.springframework.data.domain.PageImpl<>(java.util.List.of(stored)));
 
-        java.util.List<ApiKeyMetadata> keys = apiKeyService.listKeys();
+        edu.harvard.hms.dbmi.avillach.auth.model.response.ApiKeyPage keyPage = apiKeyService.listKeys(0, 100);
 
-        assertEquals(1, keys.size());
-        ApiKeyMetadata metadata = keys.get(0);
+        assertEquals(1, keyPage.totalCount());
+        assertEquals(1, keyPage.keys().size());
+        ApiKeyMetadata metadata = keyPage.keys().get(0);
         assertEquals(stored.getUuid(), metadata.uuid());
         assertEquals("abcdefgh", metadata.displayPrefix());
         assertEquals(ApiKeyType.PLATFORM, metadata.keyType());

--- a/pic-sure-auth-services/src/test/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/ApiKeyServiceTest.java
+++ b/pic-sure-auth-services/src/test/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/ApiKeyServiceTest.java
@@ -47,7 +47,7 @@ public class ApiKeyServiceTest {
 
     @Test
     public void testGenerateUserKey_formatAndPersistedFields() {
-        ApiKeyCreationResponse response = apiKeyService.generateUserKey("user@example.com");
+        ApiKeyCreationResponse response = apiKeyService.generateUserKey(null, "user@example.com");
 
         assertTrue(response.apiKey().matches("^picsure_[0-9A-Za-z]{43}$"));
         assertEquals(response.apiKey().substring("picsure_".length(), "picsure_".length() + 8), response.displayPrefix());
@@ -72,7 +72,7 @@ public class ApiKeyServiceTest {
     public void testGenerateUserKey_withPepperUsesHmacScheme() {
         apiKeyService = new ApiKeyService(apiKeyRepository, "test-pepper", "", USER_TTL_DAYS);
 
-        ApiKeyCreationResponse response = apiKeyService.generateUserKey(null);
+        ApiKeyCreationResponse response = apiKeyService.generateUserKey(null, null);
 
         ArgumentCaptor<ApiKey> captor = ArgumentCaptor.forClass(ApiKey.class);
         verify(apiKeyRepository).save(captor.capture());
@@ -97,7 +97,7 @@ public class ApiKeyServiceTest {
 
     @Test
     public void testVerifyKey_validKey() {
-        ApiKeyCreationResponse response = apiKeyService.generateUserKey(null);
+        ApiKeyCreationResponse response = apiKeyService.generateUserKey(null, null);
         ApiKey stored = storedKeyFor(response);
         when(apiKeyRepository.findByKeyHash(stored.getKeyHash())).thenReturn(Optional.of(stored));
 
@@ -123,7 +123,7 @@ public class ApiKeyServiceTest {
 
     @Test
     public void testVerifyKey_revokedKey() {
-        ApiKeyCreationResponse response = apiKeyService.generateUserKey(null);
+        ApiKeyCreationResponse response = apiKeyService.generateUserKey(null, null);
         ApiKey stored = storedKeyFor(response).setRevokedAt(Instant.now());
         when(apiKeyRepository.findByKeyHash(stored.getKeyHash())).thenReturn(Optional.of(stored));
 
@@ -132,7 +132,7 @@ public class ApiKeyServiceTest {
 
     @Test
     public void testVerifyKey_expiredKey() {
-        ApiKeyCreationResponse response = apiKeyService.generateUserKey(null);
+        ApiKeyCreationResponse response = apiKeyService.generateUserKey(null, null);
         ApiKey stored = storedKeyFor(response).setExpiresAt(Instant.now().minusSeconds(1));
         when(apiKeyRepository.findByKeyHash(stored.getKeyHash())).thenReturn(Optional.of(stored));
 
@@ -142,7 +142,7 @@ public class ApiKeyServiceTest {
     @Test
     public void testVerifyKey_prePepperKeyStillVerifiesAfterPepperEnabled() {
         // key minted while no pepper was configured...
-        ApiKeyCreationResponse response = apiKeyService.generateUserKey(null);
+        ApiKeyCreationResponse response = apiKeyService.generateUserKey(null, null);
         ApiKey stored = storedKeyFor(response);
         when(apiKeyRepository.findByKeyHash(anyString())).thenReturn(Optional.empty());
         when(apiKeyRepository.findByKeyHash(stored.getKeyHash())).thenReturn(Optional.of(stored));
@@ -157,7 +157,7 @@ public class ApiKeyServiceTest {
 
     @Test
     public void testVerifyKey_updatesLastUsedWhenStale() {
-        ApiKeyCreationResponse response = apiKeyService.generateUserKey(null);
+        ApiKeyCreationResponse response = apiKeyService.generateUserKey(null, null);
         ApiKey stored = storedKeyFor(response).setLastUsedAt(Instant.now().minusSeconds(300));
         when(apiKeyRepository.findByKeyHash(stored.getKeyHash())).thenReturn(Optional.of(stored));
         clearInvocations(apiKeyRepository);
@@ -170,7 +170,7 @@ public class ApiKeyServiceTest {
 
     @Test
     public void testVerifyKey_skipsLastUsedWriteWhenRecent() {
-        ApiKeyCreationResponse response = apiKeyService.generateUserKey(null);
+        ApiKeyCreationResponse response = apiKeyService.generateUserKey(null, null);
         ApiKey stored = storedKeyFor(response).setLastUsedAt(Instant.now().minusSeconds(5));
         when(apiKeyRepository.findByKeyHash(stored.getKeyHash())).thenReturn(Optional.of(stored));
         clearInvocations(apiKeyRepository);
@@ -206,7 +206,7 @@ public class ApiKeyServiceTest {
     public void testVerifyKey_keyFromRotatedPepperStillVerifies() {
         // key minted under the old pepper...
         ApiKeyService oldPepperService = new ApiKeyService(apiKeyRepository, "old-pepper", "", USER_TTL_DAYS);
-        ApiKeyCreationResponse response = oldPepperService.generateUserKey(null);
+        ApiKeyCreationResponse response = oldPepperService.generateUserKey(null, null);
         ApiKey stored = storedKeyFor(response);
         when(apiKeyRepository.findByKeyHash(anyString())).thenReturn(Optional.empty());
         when(apiKeyRepository.findByKeyHash(stored.getKeyHash())).thenReturn(Optional.of(stored));
@@ -223,7 +223,7 @@ public class ApiKeyServiceTest {
     @Test
     public void testVerifyKey_keyFromTwoRotationsAgoVerifiesViaPepperList() {
         ApiKeyService oldestPepperService = new ApiKeyService(apiKeyRepository, "pepper-v1", "", USER_TTL_DAYS);
-        ApiKeyCreationResponse response = oldestPepperService.generateUserKey(null);
+        ApiKeyCreationResponse response = oldestPepperService.generateUserKey(null, null);
         ApiKey stored = storedKeyFor(response);
         when(apiKeyRepository.findByKeyHash(anyString())).thenReturn(Optional.empty());
         when(apiKeyRepository.findByKeyHash(stored.getKeyHash())).thenReturn(Optional.of(stored));
@@ -235,7 +235,7 @@ public class ApiKeyServiceTest {
 
     @Test
     public void testVerifyKey_lastUsedWriteFailureDoesNotRejectKey() {
-        ApiKeyCreationResponse response = apiKeyService.generateUserKey(null);
+        ApiKeyCreationResponse response = apiKeyService.generateUserKey(null, null);
         ApiKey stored = storedKeyFor(response);
         when(apiKeyRepository.findByKeyHash(stored.getKeyHash())).thenReturn(Optional.of(stored));
         when(apiKeyRepository.touchLastUsed(any(UUID.class), any(Instant.class))).thenThrow(new RuntimeException("db is read-only"));
@@ -273,7 +273,7 @@ public class ApiKeyServiceTest {
         // key minted under a pepper, presented to a service with no peppers at all: the SHA256
         // fallback lookup must not accept the HMAC-schemed row
         ApiKeyService pepperedService = new ApiKeyService(apiKeyRepository, "test-pepper", "", USER_TTL_DAYS);
-        ApiKeyCreationResponse response = pepperedService.generateUserKey(null);
+        ApiKeyCreationResponse response = pepperedService.generateUserKey(null, null);
         ApiKey stored = storedKeyFor(response);
         when(apiKeyRepository.findByKeyHash(anyString())).thenReturn(Optional.empty());
         when(apiKeyRepository.findByKeyHash(stored.getKeyHash())).thenReturn(Optional.of(stored));
@@ -283,7 +283,7 @@ public class ApiKeyServiceTest {
 
     @Test
     public void testCreationResponse_toStringRedactsPlaintext() {
-        ApiKeyCreationResponse response = apiKeyService.generateUserKey(null);
+        ApiKeyCreationResponse response = apiKeyService.generateUserKey(null, null);
 
         assertFalse(response.toString().contains(response.apiKey()));
         assertTrue(response.toString().contains(response.displayPrefix()));

--- a/pic-sure-auth-services/src/test/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/ApiKeyServiceTest.java
+++ b/pic-sure-auth-services/src/test/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/ApiKeyServiceTest.java
@@ -302,7 +302,7 @@ public class ApiKeyServiceTest {
         when(apiKeyRepository.findAll(any(org.springframework.data.domain.Pageable.class)))
             .thenReturn(new org.springframework.data.domain.PageImpl<>(java.util.List.of(stored)));
 
-        edu.harvard.hms.dbmi.avillach.auth.model.response.ApiKeyPage keyPage = apiKeyService.listKeys(0, 100);
+        edu.harvard.hms.dbmi.avillach.auth.model.response.ApiKeyPage keyPage = apiKeyService.listKeys(0, 100, null);
 
         assertEquals(1, keyPage.totalCount());
         assertEquals(1, keyPage.keys().size());
@@ -316,6 +316,21 @@ public class ApiKeyServiceTest {
         assertEquals(expiresAt, metadata.expiresAt());
         assertEquals(revokedAt, metadata.revokedAt());
         assertEquals(lastUsedAt, metadata.lastUsedAt());
+    }
+
+    @Test
+    public void testListKeys_filtersByKeyType() {
+        ApiKey stored = new ApiKey().setKeyHash("deadbeef").setHashScheme(ApiKeyService.SCHEME_SHA256).setDisplayPrefix("abcdefgh")
+            .setKeyType(ApiKeyType.PLATFORM).setCreatedAt(Instant.now()).setExpiresAt(Instant.now().plusSeconds(3600));
+        stored.setUuid(UUID.randomUUID());
+        when(apiKeyRepository.findByKeyType(eq(ApiKeyType.PLATFORM), any(org.springframework.data.domain.Pageable.class)))
+            .thenReturn(new org.springframework.data.domain.PageImpl<>(java.util.List.of(stored)));
+
+        edu.harvard.hms.dbmi.avillach.auth.model.response.ApiKeyPage keyPage = apiKeyService.listKeys(0, 100, ApiKeyType.PLATFORM);
+
+        assertEquals(1, keyPage.keys().size());
+        assertEquals(ApiKeyType.PLATFORM, keyPage.keys().get(0).keyType());
+        verify(apiKeyRepository, never()).findAll(any(org.springframework.data.domain.Pageable.class));
     }
 
     @Test

--- a/pic-sure-auth-services/src/test/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/ApiKeyServiceTest.java
+++ b/pic-sure-auth-services/src/test/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/ApiKeyServiceTest.java
@@ -165,7 +165,7 @@ public class ApiKeyServiceTest {
 
         apiKeyService.verifyKey(response.apiKey());
 
-        verify(apiKeyRepository).touchLastUsed(eq(stored.getUuid()), any(Instant.class));
+        verify(apiKeyRepository).touchLastUsed(eq(stored.getUuid()), any(Instant.class), any(Instant.class));
         verify(apiKeyRepository, never()).save(any(ApiKey.class));
     }
 
@@ -178,7 +178,7 @@ public class ApiKeyServiceTest {
 
         assertTrue(apiKeyService.verifyKey(response.apiKey()).isPresent());
 
-        verify(apiKeyRepository, never()).touchLastUsed(any(UUID.class), any(Instant.class));
+        verify(apiKeyRepository, never()).touchLastUsed(any(UUID.class), any(Instant.class), any(Instant.class));
         verify(apiKeyRepository, never()).save(any(ApiKey.class));
     }
 
@@ -239,7 +239,8 @@ public class ApiKeyServiceTest {
         ApiKeyCreationResponse response = apiKeyService.generateUserKey(null, null);
         ApiKey stored = storedKeyFor(response);
         when(apiKeyRepository.findByKeyHash(stored.getKeyHash())).thenReturn(Optional.of(stored));
-        when(apiKeyRepository.touchLastUsed(any(UUID.class), any(Instant.class))).thenThrow(new RuntimeException("db is read-only"));
+        when(apiKeyRepository.touchLastUsed(any(UUID.class), any(Instant.class), any(Instant.class)))
+            .thenThrow(new RuntimeException("db is read-only"));
 
         assertTrue(apiKeyService.verifyKey(response.apiKey()).isPresent());
     }

--- a/pic-sure-auth-services/src/test/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/ApiKeyServiceTest.java
+++ b/pic-sure-auth-services/src/test/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/ApiKeyServiceTest.java
@@ -32,6 +32,7 @@ import static org.mockito.Mockito.*;
 public class ApiKeyServiceTest {
 
     private static final long USER_TTL_DAYS = 90;
+    private static final long PLATFORM_TTL_DAYS = 365;
 
     @MockBean
     private ApiKeyRepository apiKeyRepository;
@@ -42,7 +43,7 @@ public class ApiKeyServiceTest {
     public void setUp() {
         MockitoAnnotations.openMocks(this);
         when(apiKeyRepository.save(any(ApiKey.class))).thenAnswer(invocation -> invocation.getArgument(0));
-        apiKeyService = new ApiKeyService(apiKeyRepository, "", "", USER_TTL_DAYS);
+        apiKeyService = new ApiKeyService(apiKeyRepository, "", "", USER_TTL_DAYS, PLATFORM_TTL_DAYS);
     }
 
     @Test
@@ -70,7 +71,7 @@ public class ApiKeyServiceTest {
 
     @Test
     public void testGenerateUserKey_withPepperUsesHmacScheme() {
-        apiKeyService = new ApiKeyService(apiKeyRepository, "test-pepper", "", USER_TTL_DAYS);
+        apiKeyService = new ApiKeyService(apiKeyRepository, "test-pepper", "", USER_TTL_DAYS, PLATFORM_TTL_DAYS);
 
         ApiKeyCreationResponse response = apiKeyService.generateUserKey(null, null);
 
@@ -85,7 +86,7 @@ public class ApiKeyServiceTest {
     public void testGeneratePlatformKey_customExpiryAndMetadata() {
         Instant expiresAt = Instant.now().plus(365, ChronoUnit.DAYS);
 
-        ApiKeyCreationResponse response = apiKeyService.generatePlatformKey("Partner X", "partner@example.com", expiresAt);
+        ApiKeyCreationResponse response = apiKeyService.generatePlatformKey("Partner X", "partner@example.com", expiresAt, false);
 
         assertEquals(ApiKeyType.PLATFORM, response.keyType());
         assertEquals(expiresAt, response.expiresAt());
@@ -148,7 +149,7 @@ public class ApiKeyServiceTest {
         when(apiKeyRepository.findByKeyHash(stored.getKeyHash())).thenReturn(Optional.of(stored));
 
         // ...must still verify on a service configured with a pepper
-        ApiKeyService pepperedService = new ApiKeyService(apiKeyRepository, "test-pepper", "", USER_TTL_DAYS);
+        ApiKeyService pepperedService = new ApiKeyService(apiKeyRepository, "test-pepper", "", USER_TTL_DAYS, PLATFORM_TTL_DAYS);
         Optional<ApiKey> verified = pepperedService.verifyKey(response.apiKey());
 
         assertTrue(verified.isPresent());
@@ -205,30 +206,30 @@ public class ApiKeyServiceTest {
     @Test
     public void testVerifyKey_keyFromRotatedPepperStillVerifies() {
         // key minted under the old pepper...
-        ApiKeyService oldPepperService = new ApiKeyService(apiKeyRepository, "old-pepper", "", USER_TTL_DAYS);
+        ApiKeyService oldPepperService = new ApiKeyService(apiKeyRepository, "old-pepper", "", USER_TTL_DAYS, PLATFORM_TTL_DAYS);
         ApiKeyCreationResponse response = oldPepperService.generateUserKey(null, null);
         ApiKey stored = storedKeyFor(response);
         when(apiKeyRepository.findByKeyHash(anyString())).thenReturn(Optional.empty());
         when(apiKeyRepository.findByKeyHash(stored.getKeyHash())).thenReturn(Optional.of(stored));
 
         // ...verifies after rotation to a new pepper with the old one kept as previous
-        ApiKeyService rotatedService = new ApiKeyService(apiKeyRepository, "new-pepper", "old-pepper", USER_TTL_DAYS);
+        ApiKeyService rotatedService = new ApiKeyService(apiKeyRepository, "new-pepper", "old-pepper", USER_TTL_DAYS, PLATFORM_TTL_DAYS);
         assertTrue(rotatedService.verifyKey(response.apiKey()).isPresent());
 
         // ...and while the current pepper is accidentally omitted entirely
-        ApiKeyService pepperlessService = new ApiKeyService(apiKeyRepository, "", "old-pepper", USER_TTL_DAYS);
+        ApiKeyService pepperlessService = new ApiKeyService(apiKeyRepository, "", "old-pepper", USER_TTL_DAYS, PLATFORM_TTL_DAYS);
         assertTrue(pepperlessService.verifyKey(response.apiKey()).isPresent());
     }
 
     @Test
     public void testVerifyKey_keyFromTwoRotationsAgoVerifiesViaPepperList() {
-        ApiKeyService oldestPepperService = new ApiKeyService(apiKeyRepository, "pepper-v1", "", USER_TTL_DAYS);
+        ApiKeyService oldestPepperService = new ApiKeyService(apiKeyRepository, "pepper-v1", "", USER_TTL_DAYS, PLATFORM_TTL_DAYS);
         ApiKeyCreationResponse response = oldestPepperService.generateUserKey(null, null);
         ApiKey stored = storedKeyFor(response);
         when(apiKeyRepository.findByKeyHash(anyString())).thenReturn(Optional.empty());
         when(apiKeyRepository.findByKeyHash(stored.getKeyHash())).thenReturn(Optional.of(stored));
 
-        ApiKeyService twiceRotatedService = new ApiKeyService(apiKeyRepository, "pepper-v3", "pepper-v2, pepper-v1", USER_TTL_DAYS);
+        ApiKeyService twiceRotatedService = new ApiKeyService(apiKeyRepository, "pepper-v3", "pepper-v2, pepper-v1", USER_TTL_DAYS, PLATFORM_TTL_DAYS);
 
         assertTrue(twiceRotatedService.verifyKey(response.apiKey()).isPresent());
     }
@@ -247,32 +248,64 @@ public class ApiKeyServiceTest {
     public void testGeneratePlatformKey_pastExpiryRejected() {
         assertThrows(
             IllegalArgumentException.class,
-            () -> apiKeyService.generatePlatformKey("Partner X", "partner@example.com", Instant.now().minusSeconds(1))
+            () -> apiKeyService.generatePlatformKey("Partner X", "partner@example.com", Instant.now().minusSeconds(1), false)
         );
         verify(apiKeyRepository, never()).save(any(ApiKey.class));
     }
 
     @Test
-    public void testGeneratePlatformKey_nullExpiryFallsBackToUserTtl() {
-        ApiKeyCreationResponse response = apiKeyService.generatePlatformKey("Partner X", "partner@example.com", null);
+    public void testGeneratePlatformKey_nullExpiryAppliesPlatformTtl() {
+        ApiKeyCreationResponse response = apiKeyService.generatePlatformKey("Partner X", "partner@example.com", null, false);
 
         ArgumentCaptor<ApiKey> captor = ArgumentCaptor.forClass(ApiKey.class);
         verify(apiKeyRepository).save(captor.capture());
-        assertEquals(USER_TTL_DAYS, ChronoUnit.DAYS.between(captor.getValue().getCreatedAt(), captor.getValue().getExpiresAt()));
+        assertEquals(PLATFORM_TTL_DAYS, ChronoUnit.DAYS.between(captor.getValue().getCreatedAt(), captor.getValue().getExpiresAt()));
         assertEquals(ApiKeyType.PLATFORM, response.keyType());
     }
 
     @Test
+    public void testGeneratePlatformKey_neverExpiresStoresNullExpiry() {
+        ApiKeyCreationResponse response = apiKeyService.generatePlatformKey("Partner X", "partner@example.com", null, true);
+
+        ArgumentCaptor<ApiKey> captor = ArgumentCaptor.forClass(ApiKey.class);
+        verify(apiKeyRepository).save(captor.capture());
+        assertNull(captor.getValue().getExpiresAt());
+        assertNull(response.expiresAt());
+    }
+
+    @Test
+    public void testGeneratePlatformKey_neverExpiresWithExplicitDateRejected() {
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> apiKeyService.generatePlatformKey("Partner X", "partner@example.com", Instant.now().plusSeconds(3600), true)
+        );
+        verify(apiKeyRepository, never()).save(any(ApiKey.class));
+    }
+
+    @Test
+    public void testVerifyKey_nullExpiryNeverExpires() {
+        ApiKeyCreationResponse response = apiKeyService.generatePlatformKey("Partner X", "partner@example.com", null, true);
+        ApiKey stored = storedKeyFor(response);
+        when(apiKeyRepository.findByKeyHash(stored.getKeyHash())).thenReturn(Optional.of(stored));
+
+        Optional<ApiKey> verified = apiKeyService.verifyKey(response.apiKey());
+
+        assertTrue(verified.isPresent());
+        assertNull(verified.get().getExpiresAt());
+    }
+
+    @Test
     public void testConstructor_rejectsNonPositiveTtl() {
-        assertThrows(IllegalStateException.class, () -> new ApiKeyService(apiKeyRepository, "", "", 0));
-        assertThrows(IllegalStateException.class, () -> new ApiKeyService(apiKeyRepository, "", "", -1));
+        assertThrows(IllegalStateException.class, () -> new ApiKeyService(apiKeyRepository, "", "", USER_TTL_DAYS, 0));
+        assertThrows(IllegalStateException.class, () -> new ApiKeyService(apiKeyRepository, "", "", 0, PLATFORM_TTL_DAYS));
+        assertThrows(IllegalStateException.class, () -> new ApiKeyService(apiKeyRepository, "", "", -1, PLATFORM_TTL_DAYS));
     }
 
     @Test
     public void testVerifyKey_hmacKeyRejectedWhenNoPeppersConfigured() {
         // key minted under a pepper, presented to a service with no peppers at all: the SHA256
         // fallback lookup must not accept the HMAC-schemed row
-        ApiKeyService pepperedService = new ApiKeyService(apiKeyRepository, "test-pepper", "", USER_TTL_DAYS);
+        ApiKeyService pepperedService = new ApiKeyService(apiKeyRepository, "test-pepper", "", USER_TTL_DAYS, PLATFORM_TTL_DAYS);
         ApiKeyCreationResponse response = pepperedService.generateUserKey(null, null);
         ApiKey stored = storedKeyFor(response);
         when(apiKeyRepository.findByKeyHash(anyString())).thenReturn(Optional.empty());

--- a/pic-sure-auth-services/src/test/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/AuthorizationServiceTest.java
+++ b/pic-sure-auth-services/src/test/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/AuthorizationServiceTest.java
@@ -22,6 +22,9 @@ import java.util.*;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @SpringBootTest
@@ -49,6 +52,9 @@ public class AuthorizationServiceTest {
     @MockBean
     private UserConsentsRepository userConsentsRepository;
 
+    @MockBean
+    private ApiKeyService apiKeyService;
+
     @BeforeEach
     public void setUp() {
         MockitoAnnotations.openMocks(this);
@@ -56,8 +62,98 @@ public class AuthorizationServiceTest {
 
         accessRuleService = new AccessRuleService(accessRuleRepository, "false", "false", "false", "false", "false", "false");
         authorizationService = new AuthorizationService(
-            accessRuleService, sessionService, roleService, bdcConsentBasedAccessRuleEvaluator, "fence,okta,open", userConsentsRepository
+            accessRuleService, sessionService, roleService, bdcConsentBasedAccessRuleEvaluator, "fence,okta,open", userConsentsRepository,
+            apiKeyService, false
         );
+    }
+
+    private AuthorizationService enforcingAuthorizationService() {
+        return new AuthorizationService(
+            accessRuleService, sessionService, roleService, bdcConsentBasedAccessRuleEvaluator, "fence,okta,open", userConsentsRepository,
+            apiKeyService, true
+        );
+    }
+
+    @Test
+    public void testOpenAccess_enforcementOff_keylessRequestKeepsLegacyBehavior() {
+        assertTrue(authorizationService.openAccessRequestIsValid(new HashMap<>()));
+        assertTrue(authorizationService.openAccessRequestIsValid(null));
+        verify(apiKeyService, never()).verifyKey(any());
+    }
+
+    @Test
+    public void testOpenAccess_enforcementOff_presentKeyIsIgnored() {
+        Map<String, Object> inputMap = new HashMap<>();
+        inputMap.put("apiKey", "picsure_anything");
+
+        assertTrue(authorizationService.openAccessRequestIsValid(inputMap));
+        verify(apiKeyService, never()).verifyKey(any());
+    }
+
+    @Test
+    public void testOpenAccess_enforcementOn_missingKeyDenied() {
+        AuthorizationService enforcing = enforcingAuthorizationService();
+
+        assertFalse(enforcing.openAccessRequestIsValid(new HashMap<>()));
+        assertFalse(enforcing.openAccessRequestIsValid(null));
+        Map<String, Object> withBody = new HashMap<>();
+        withBody.put("request", Map.of("Target Service", "/query/sync"));
+        assertFalse(enforcing.openAccessRequestIsValid(withBody));
+        verify(roleService, never()).getRoleByName(any());
+    }
+
+    @Test
+    public void testOpenAccess_enforcementOn_invalidKeyDenied() {
+        when(apiKeyService.verifyKey("picsure_invalid")).thenReturn(Optional.empty());
+        AuthorizationService enforcing = enforcingAuthorizationService();
+
+        Map<String, Object> inputMap = new HashMap<>();
+        inputMap.put("apiKey", "picsure_invalid");
+        inputMap.put("request", Map.of("Target Service", "/query/sync"));
+
+        assertFalse(enforcing.openAccessRequestIsValid(inputMap));
+        // denial must come from the key gate, not from the legacy role evaluation
+        verify(roleService, never()).getRoleByName(any());
+    }
+
+    @Test
+    public void testOpenAccess_enforcementOn_emptyStringKeyDenied() {
+        when(apiKeyService.verifyKey("")).thenReturn(Optional.empty());
+        AuthorizationService enforcing = enforcingAuthorizationService();
+
+        Map<String, Object> inputMap = new HashMap<>();
+        inputMap.put("apiKey", "");
+
+        assertFalse(enforcing.openAccessRequestIsValid(inputMap));
+        verify(roleService, never()).getRoleByName(any());
+    }
+
+    @Test
+    public void testOpenAccess_enforcementOn_nonStringKeyDenied() {
+        AuthorizationService enforcing = enforcingAuthorizationService();
+
+        Map<String, Object> inputMap = new HashMap<>();
+        inputMap.put("apiKey", 12345);
+
+        assertFalse(enforcing.openAccessRequestIsValid(inputMap));
+        verify(apiKeyService, never()).verifyKey(any());
+    }
+
+    @Test
+    public void testOpenAccess_enforcementOn_validKeyProceedsToLegacyEvaluation() {
+        when(apiKeyService.verifyKey("picsure_valid")).thenReturn(Optional.of(new ApiKey()));
+        AuthorizationService enforcing = enforcingAuthorizationService();
+
+        // valid key + no request body falls through to the legacy grant
+        Map<String, Object> inputMap = new HashMap<>();
+        inputMap.put("apiKey", "picsure_valid");
+        assertTrue(enforcing.openAccessRequestIsValid(inputMap));
+
+        // valid key + request body reaches the role/access-rule evaluation
+        when(roleService.getRoleByName(any())).thenReturn(null);
+        inputMap.put("request", Map.of("Target Service", "/query/sync"));
+        assertFalse(enforcing.openAccessRequestIsValid(inputMap));
+        verify(roleService).getRoleByName(any());
     }
 
     @Test

--- a/pic-sure-auth-services/src/test/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/authorization/AuthorizationServiceTest.java
+++ b/pic-sure-auth-services/src/test/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/authorization/AuthorizationServiceTest.java
@@ -51,6 +51,9 @@ public class AuthorizationServiceTest {
     @MockBean
     private UserConsentsRepository userConsentsRepository;
 
+    @MockBean
+    private edu.harvard.hms.dbmi.avillach.auth.service.impl.ApiKeyService apiKeyService;
+
     private final ObjectMapper mapper = new ObjectMapper();
 
     private static AccessRule GATE_resouceUUID;
@@ -215,7 +218,8 @@ public class AuthorizationServiceTest {
         when(sessionService.isSessionExpired(any(String.class))).thenReturn(false);
         accessRuleService = new AccessRuleService(accessRuleRepository, "false", "false", "false", "false", "false", "false");
         authorizationService = new AuthorizationService(
-            accessRuleService, sessionService, roleService, bdcConsentBasedAccessRuleEvaluator, "fence,okta", userConsentsRepository
+            accessRuleService, sessionService, roleService, bdcConsentBasedAccessRuleEvaluator, "fence,okta", userConsentsRepository,
+            apiKeyService, false
         );
     }
 

--- a/pic-sure-auth-services/src/test/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/captcha/DisabledCaptchaVerifierTest.java
+++ b/pic-sure-auth-services/src/test/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/captcha/DisabledCaptchaVerifierTest.java
@@ -1,0 +1,30 @@
+package edu.harvard.hms.dbmi.avillach.auth.service.impl.captcha;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class DisabledCaptchaVerifierTest {
+
+    @Test
+    public void testFailsStartupWhenGenerationEnabledWithoutExplicitOptIn() {
+        DisabledCaptchaVerifier verifier = new DisabledCaptchaVerifier(true, false);
+
+        assertThrows(IllegalStateException.class, verifier::enforceExplicitOptIn);
+    }
+
+    @Test
+    public void testStartsWhenUngatedGenerationExplicitlyAllowed() {
+        DisabledCaptchaVerifier verifier = new DisabledCaptchaVerifier(true, true);
+
+        assertDoesNotThrow(verifier::enforceExplicitOptIn);
+        assertTrue(verifier.verify(null, null));
+    }
+
+    @Test
+    public void testStartsWhenGenerationDisabled() {
+        assertDoesNotThrow(new DisabledCaptchaVerifier(false, false)::enforceExplicitOptIn);
+    }
+}


### PR DESCRIPTION
## What

Adds API keys for open-access (token-less) requests, gated behind config flags that default off:

- `api_key` table (V10): hashed key material only (`key_hash` + `hash_scheme`), 8-char display prefix, USER/PLATFORM type, nullable `expires_at` with a CHECK that USER keys always expire.
- `ApiKeyService`: 256-bit `picsure_` keys, HMAC-SHA256 with pepper rotation (previous-pepper ladder, unpeppered SHA-256 fallback for keys minted before a pepper existed), throttled race-safe `last_used_at` updates.
- Endpoints: public CAPTCHA-gated `POST /open/apiKey` (USER keys, behind `api.key.generation.enabled`), admin `GET /apiKey` (paged, filterable by `keyType`), SUPER_ADMIN `POST /apiKey/platform` and `PUT /apiKey/{id}/revoke`. Plaintext appears only in the creation response; `toString` is redacted.
- Enforcement hook in `AuthorizationService.openAccessRequestIsValid` behind `api.key.enforcement.enabled` (default off): when on, every open-access request must present a valid key before the legacy evaluation runs.
- CAPTCHA: `CaptchaVerifier` interface + disabled default implementation; a real provider (Turnstile) is a follow-up.

## Expiry semantics

- USER keys: always expire (`api.key.user.ttl.days`, default 90).
- PLATFORM keys: explicit `expiresAt`, or `neverExpires: true` (mutually exclusive), or neither → `api.key.platform.ttl.days` (default 365).

## Also in this PR

`GlobalExceptionHandler` now maps `MethodArgumentTypeMismatchException` to 400 (previously any mistyped request param anywhere in the service returned 500), which lets `keyType` bind directly as an enum.

## Deferred (tracked separately)

- Deployment env wiring (`API_KEY_*` vars, pepper generation at install).
- Parallel migrations for the deployment repos that keep self-contained Flyway histories.
- Turnstile CAPTCHA implementation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added API key creation for users and platform administrators, including expiration and an option for never-expiring platform keys.
  * Added API key listing (with pagination and optional type filtering), metadata viewing, and revocation.
  * Added optional CAPTCHA protection for self-service key generation.
  * Added configurable API-key enforcement for open-access requests.
* **Security**
  * API keys are stored securely (hashed) and plaintext is kept out of logs; creation responses redact sensitive values.
* **Bug Fixes**
  * Invalid request payloads and parameter type mismatches now return clear `400 Bad Request` errors.
* **Tests**
  * Added/updated coverage for object serialization and the API key request/response flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
