### PR TITLE
[Bug] Consider selected harmonized var when calc-ing auth

### DIFF
--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/authorization/BdcConsentBasedAccessRuleEvaluator.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/authorization/BdcConsentBasedAccessRuleEvaluator.java
@@ -22,6 +22,7 @@ public class BdcConsentBasedAccessRuleEvaluator implements ConsentBasedAccessRul
 
     private static final String GENOMIC_AUTHORIZATION_FILTER = "\\_topmed_consents\\";
     private static final String HARMONIZED_AUTHORIZATION_FILTER = "\\_harmonized_consent\\";
+    private static final String HARMONIZED_CONCEPT_PATH_PREFIX = "\\DCC Harmonized data set\\";
     private static final Set<String> ALWAYS_ALLOWED_CONCEPT_ROOTS = Set.of("_Topmed Study Accession with Subject ID", "_Parent Study Accession with Subject ID", "_consents", "_harmonized_consent", "_topmed_consents");
 
     @Override
@@ -77,10 +78,10 @@ public class BdcConsentBasedAccessRuleEvaluator implements ConsentBasedAccessRul
                 return false;
             }
             if (entry.getKey().equals(HARMONIZED_AUTHORIZATION_FILTER)) {
-                long harmonizedFilterCount =
-                    query.allFilters().stream().filter(filter -> filter.conceptPath().startsWith("\\DCC Harmonized data set\\")).count();
-                // leave these consents if there are any filters on harmonized concept paths
-                return harmonizedFilterCount > 0;
+                boolean filtersOnHarmonized =
+                    query.allFilters().stream().anyMatch(filter -> filter.conceptPath().startsWith(HARMONIZED_CONCEPT_PATH_PREFIX));
+                boolean selectsHarmonized = query.select().stream().anyMatch(path -> path.startsWith(HARMONIZED_CONCEPT_PATH_PREFIX));
+                return filtersOnHarmonized || selectsHarmonized;
             }
             return true;
         }).map(entry -> new AuthorizationFilter(entry.getKey(), entry.getValue())).toList();

--- a/pic-sure-auth-services/src/test/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/authorization/BdcConsentBasedAccessRuleEvaluatorTest.java
+++ b/pic-sure-auth-services/src/test/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/authorization/BdcConsentBasedAccessRuleEvaluatorTest.java
@@ -218,6 +218,59 @@ class BdcConsentBasedAccessRuleEvaluatorTest {
     }
 
     @Test
+    public void setAuthorizationFiltersForQuery_harmonizedInFiltersOnly_keepHarmonizedConsent() {
+        UserConsents userConsents = new UserConsents().setConsents(Map.of("\\_consents\\", Set.of("phs123.c1"), "\\_harmonized_consent\\", Set.of("phs789.c1")));
+        Query query = new Query(
+                List.of(), List.of(),
+                new PhenotypicSubquery(
+                        null,
+                        List.of(
+                                new PhenotypicFilter(PhenotypicFilterType.FILTER, "\\DCC Harmonized data set\\data\\age\\", null, 30.0, 40.0, null)
+                        ), Operator.AND
+                ), null, ResultType.COUNT, null, null
+        );
+
+        Query queryWithConsents = bdcConsentBasedAccessRuleEvaluator.setAuthorizationFiltersForQuery(userConsents, query);
+        assertEquals(2, queryWithConsents.authorizationFilters().size());
+        assertTrue(queryWithConsents.authorizationFilters().contains(new AuthorizationFilter("\\_harmonized_consent\\", Set.of("phs789.c1"))));
+    }
+
+    @Test
+    public void setAuthorizationFiltersForQuery_harmonizedInSelectOnly_keepHarmonizedConsent() {
+        UserConsents userConsents = new UserConsents().setConsents(Map.of("\\_consents\\", Set.of("phs123.c1"), "\\_harmonized_consent\\", Set.of("phs789.c1")));
+        Query query = new Query(
+                List.of("\\DCC Harmonized data set\\data\\age\\", "\\phs123\\data\\age\\"), List.of(),
+                new PhenotypicSubquery(
+                        null,
+                        List.of(
+                                new PhenotypicFilter(PhenotypicFilterType.FILTER, "\\phs123\\data\\age\\", null, 30.0, 40.0, null)
+                        ), Operator.AND
+                ), null, ResultType.DATAFRAME, null, null
+        );
+
+        Query queryWithConsents = bdcConsentBasedAccessRuleEvaluator.setAuthorizationFiltersForQuery(userConsents, query);
+        assertEquals(2, queryWithConsents.authorizationFilters().size());
+        assertTrue(queryWithConsents.authorizationFilters().contains(new AuthorizationFilter("\\_harmonized_consent\\", Set.of("phs789.c1"))));
+    }
+
+    @Test
+    public void setAuthorizationFiltersForQuery_noHarmonizedInSelectOrFilters_dropHarmonizedConsent() {
+        UserConsents userConsents = new UserConsents().setConsents(Map.of("\\_consents\\", Set.of("phs123.c1"), "\\_harmonized_consent\\", Set.of("phs789.c1")));
+        Query query = new Query(
+                List.of("\\phs123\\data\\age\\", "\\phs123\\data\\sex\\"), List.of(),
+                new PhenotypicSubquery(
+                        null,
+                        List.of(
+                                new PhenotypicFilter(PhenotypicFilterType.FILTER, "\\phs123\\data\\age\\", null, 30.0, 40.0, null)
+                        ), Operator.AND
+                ), null, ResultType.DATAFRAME, null, null
+        );
+
+        Query queryWithConsents = bdcConsentBasedAccessRuleEvaluator.setAuthorizationFiltersForQuery(userConsents, query);
+        assertEquals(List.of(new AuthorizationFilter("\\_consents\\", Set.of("phs123.c1"))), queryWithConsents.authorizationFilters());
+    }
+
+    @Test
     public void evaluateAccessRule_filterIncludesTopmedAndParentStudyId_accept() {
         UserConsents userConsents = new UserConsents().setConsents(Map.of("\\_consents\\", Set.of("phs123.c1", "phs456.c2")));
         Query query = new Query(


### PR DESCRIPTION
Keep harmonized authorization filter for queries that select harmonized concepts

setAuthorizationFiltersForQuery decided whether to keep the \_harmonized_consent\ authorization filter by scanning query.allFilters() only. An export/DATAFRAME query that selects \DCC Harmonized data set\ concepts without also filtering on them therefore lost its harmonized authorization filter.

evaluateAccessRule in the same class already checks both allFilters() and select(); this restores that symmetry: the harmonized filter is kept when either the filters or the select list reference a harmonized concept path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved authorization handling for harmonized datasets.
  - Harmonized consent access is now retained when harmonized data appears in either query filters or selected fields.
  - Unneeded harmonized consent filters are removed when the query does not reference harmonized data.

- **Tests**
  - Added coverage for harmonized data referenced through filters, selections, or neither.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->