### PR TITLE
[ALS-10701] Fix broken GET /user/me/consents endpoint

### DIFF
--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/rest/UserController.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/rest/UserController.java
@@ -178,9 +178,10 @@ public class UserController {
     }
 
     @Operation(description = "Retrieve consents of current user")
+    @AuditEvent(type = "ACCESS", action = "user.consents")
     @GetMapping(path = "/me/consents", produces = "application/json")
-    public ResponseEntity<?> getUserConsents(@PathVariable("userId") UUID userId) {
-        UserConsents userConsents = this.userService.getUserConsents(userId);
+    public ResponseEntity<?> getUserConsents() {
+        UserConsents userConsents = this.userService.getUserConsents();
 
         if (userConsents == null) {
             return PICSUREResponse.applicationError("Inner application error, please contact admin.");

--- a/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/UserService.java
+++ b/pic-sure-auth-services/src/main/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/UserService.java
@@ -30,6 +30,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.http.HttpHeaders;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
@@ -838,16 +839,20 @@ public class UserService {
         return user;
     }
 
-    public UserConsents getUserConsents(UUID userId) {
+    public UserConsents getUserConsents() {
         SecurityContext securityContext = SecurityContextHolder.getContext();
-        CustomUserDetails customUserDetails = (CustomUserDetails) securityContext.getAuthentication().getPrincipal();
-        if (customUserDetails == null || customUserDetails.getUser() == null || customUserDetails.getUser().getUuid() == null) {
+        Authentication authentication = securityContext.getAuthentication();
+        if (authentication == null || !(authentication.getPrincipal() instanceof CustomUserDetails customUserDetails)
+            || customUserDetails.getUser() == null || customUserDetails.getUser().getUuid() == null) {
             logger.error("Security context didn't have a user stored.");
             return null;
-        } else if (customUserDetails.getUser().getUuid() != userId) {
-            logger.error("User " + customUserDetails.getUser().getUuid() + " tried to access consents for user " + userId);
-            return null;
         }
-        return userConsentsRepository.findByUserId(userId);
+
+        UUID userId = customUserDetails.getUser().getUuid();
+        UserConsents userConsents = userConsentsRepository.findByUserId(userId);
+        if (userConsents == null) {
+            return new UserConsents().setUserId(userId).setConsents(Map.of()); //non-bdc
+        }
+        return userConsents;
     }
 }

--- a/pic-sure-auth-services/src/test/java/edu/harvard/hms/dbmi/avillach/auth/rest/ControllerAuditEventTest.java
+++ b/pic-sure-auth-services/src/test/java/edu/harvard/hms/dbmi/avillach/auth/rest/ControllerAuditEventTest.java
@@ -56,6 +56,8 @@ class ControllerAuditEventTest {
         assertAuditEvent(c, "getQueryTemplate", new Class[]{}, "ACCESS", "user.profile");
         // refreshUserToken(HttpHeaders httpHeaders, HttpServletRequest request)
         assertAuditEvent(c, "refreshUserToken", new Class[]{HttpHeaders.class, HttpServletRequest.class}, "ACCESS", "user.profile");
+        // getUserConsents() - no params
+        assertAuditEvent(c, "getUserConsents", new Class[]{}, "ACCESS", "user.consents");
     }
 
     @Test

--- a/pic-sure-auth-services/src/test/java/edu/harvard/hms/dbmi/avillach/auth/rest/UserControllerWebTest.java
+++ b/pic-sure-auth-services/src/test/java/edu/harvard/hms/dbmi/avillach/auth/rest/UserControllerWebTest.java
@@ -1,0 +1,77 @@
+package edu.harvard.hms.dbmi.avillach.auth.rest;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import edu.harvard.hms.dbmi.avillach.auth.entity.UserConsents;
+import edu.harvard.hms.dbmi.avillach.auth.exceptions.GlobalExceptionHandler;
+import edu.harvard.hms.dbmi.avillach.auth.service.impl.UserService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Standalone MockMvc tests: exercise real request-mapping and argument resolution, which plain
+ * controller unit tests bypass (a stray @PathVariable only fails when the mapping is exercised).
+ */
+public class UserControllerWebTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private MockMvc mockMvc;
+    private UserService userService;
+
+    @BeforeEach
+    public void setUp() {
+        userService = Mockito.mock(UserService.class);
+        UserController controller = new UserController(userService);
+        mockMvc = MockMvcBuilders.standaloneSetup(controller).setControllerAdvice(new GlobalExceptionHandler()).build();
+    }
+
+    @Test
+    public void getUserConsents_withConsents_returns200WithConsentsMap() throws Exception {
+        UserConsents userConsents = new UserConsents()
+            .setUserId(UUID.randomUUID())
+            .setConsents(Map.of("\\_consents\\", Set.of("phs1234.c1")));
+        when(userService.getUserConsents()).thenReturn(userConsents);
+
+        MvcResult result = mockMvc.perform(get("/user/me/consents")).andExpect(status().isOk()).andReturn();
+
+        JsonNode consents = MAPPER.readTree(result.getResponse().getContentAsString()).get("consents");
+        assertNotNull(consents);
+        JsonNode studies = consents.get("\\_consents\\");
+        assertNotNull(studies);
+        assertEquals(1, studies.size());
+        assertEquals("phs1234.c1", studies.get(0).asText());
+    }
+
+    @Test
+    public void getUserConsents_noConsentsRow_returns200WithEmptyConsentsMap() throws Exception {
+        when(userService.getUserConsents()).thenReturn(new UserConsents().setUserId(UUID.randomUUID()).setConsents(Map.of()));
+
+        MvcResult result = mockMvc.perform(get("/user/me/consents")).andExpect(status().isOk()).andReturn();
+
+        JsonNode consents = MAPPER.readTree(result.getResponse().getContentAsString()).get("consents");
+        assertNotNull(consents);
+        assertTrue(consents.isObject());
+        assertTrue(consents.isEmpty());
+    }
+
+    @Test
+    public void getUserConsents_noUsablePrincipal_returns500() throws Exception {
+        when(userService.getUserConsents()).thenReturn(null);
+
+        mockMvc.perform(get("/user/me/consents")).andExpect(status().isInternalServerError());
+    }
+}

--- a/pic-sure-auth-services/src/test/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/UserServiceTest.java
+++ b/pic-sure-auth-services/src/test/java/edu/harvard/hms/dbmi/avillach/auth/service/impl/UserServiceTest.java
@@ -603,6 +603,55 @@ public class UserServiceTest {
         assertEquals(Map.of("\\_consents\\", Set.of("phs1234.c1")), userConsentsCaptor.getValue().getConsents());
     }
 
+    @Test
+    public void getUserConsents_withConsents() {
+        User user = createTestUser();
+        configureUserSecurityContext(user);
+        UserConsents storedConsents = new UserConsents()
+                .setUserId(user.getUuid())
+                .setConsents(Map.of("\\_consents\\", Set.of("phs1234.c1")));
+        when(userConsentsRepository.findByUserId(user.getUuid())).thenReturn(storedConsents);
+
+        UserConsents result = userService.getUserConsents();
+
+        assertEquals(storedConsents, result);
+        assertEquals(Map.of("\\_consents\\", Set.of("phs1234.c1")), result.getConsents());
+        verify(userConsentsRepository).findByUserId(user.getUuid());
+    }
+
+    @Test
+    public void getUserConsents_noConsentsRow_returnsEmptyConsents() {
+        User user = createTestUser();
+        configureUserSecurityContext(user);
+        when(userConsentsRepository.findByUserId(user.getUuid())).thenReturn(null);
+
+        UserConsents result = userService.getUserConsents();
+
+        assertNotNull(result);
+        assertEquals(user.getUuid(), result.getUserId());
+        assertEquals(Map.of(), result.getConsents());
+        verify(userConsentsRepository, never()).save(any());
+    }
+
+    @Test
+    public void getUserConsents_noUserInContext_returnsNull() {
+        CustomUserDetails customUserDetails = new CustomUserDetails(null);
+        UsernamePasswordAuthenticationToken authentication =
+                new UsernamePasswordAuthenticationToken(customUserDetails, null, customUserDetails.getAuthorities());
+        when(securityContext.getAuthentication()).thenReturn(authentication);
+
+        assertNull(userService.getUserConsents());
+        verify(userConsentsRepository, never()).findByUserId(any());
+    }
+
+    @Test
+    public void getUserConsents_noAuthentication_returnsNull() {
+        when(securityContext.getAuthentication()).thenReturn(null);
+
+        assertNull(userService.getUserConsents());
+        verify(userConsentsRepository, never()).findByUserId(any());
+    }
+
     private UserClaims buildTestUserClaims(User user) {
         UserClaims userClaims = new UserClaims();
         userClaims.setUuid(user.getUuid().toString());


### PR DESCRIPTION
The endpoint (added in ALS-9545) failed on every request:

- @PathVariable("userId") with no {userId} in the path threw MissingPathVariableException, a 500 on every call. Identity now comes from the authenticated principal only; no caller-supplied id.
- The service compared boxed UUIDs with !=, rejecting every caller. The check is deleted outright: with no caller-supplied id there is nothing to compare against.
- A user with no user_consents row (the normal state on non-consent deployments like all-in-one and GIC) got the same bare 500 as a real outage, so the frontend's fail-closed retry logic would error on every login. No row now returns 200 with an empty consents map; null (and its 500) is reserved for a broken security context.

Also adds the @AuditEvent annotation this endpoint was alone in missing, service tests for the three states, and a standalone-MockMvc controller test - the layer that would have caught the path-variable defect, which is invisible to plain unit tests.